### PR TITLE
sdk: B402Solana wires shield + unshield against deployed pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,33 @@ strategy-copying bots, not patient analysts — Layer 1 is sufficient.
 - Tests: primitives, Rust ↔ TS parity, witness generation, end-to-end snarkjs prove-verify (37 total)
 
 ### SDK (`packages/sdk/`)
-- `shield(params)` — build + submit a shield tx
-- `unshield(params)` — build + submit an unshield tx, supports merkle-proof override or `ClientMerkleTree`
-- `Scanner` — log-subscription + viewtag-filtered note discovery
-- `ClientMerkleTree`, `buildWallet`, `NoteStore` — client-side crypto primitives
+
+**`B402Solana`** — the recommended integration surface. Two-line shield + unshield:
+
+```ts
+import { B402Solana } from '@b402ai/solana';
+
+const b402 = new B402Solana({
+  cluster: 'devnet',
+  keypair,                                                  // your Solana signer
+  proverArtifacts: {
+    wasmPath: 'circuits/build/transact_js/transact.wasm',
+    zkeyPath: 'circuits/build/ceremony/transact_final.zkey',
+  },
+});
+
+const shieldRes   = await b402.shield({ mint: USDC, amount: 100_000_000n });
+const unshieldRes = await b402.unshield({ to: recipientPubkey });    // spends the just-shielded note
+```
+
+End-to-end runnable example: `examples/sdk-quick.ts`. Wraps wallet build,
+ATA derivation, tree fetch, and merkle-proof construction internally.
+`privateSwap` / `privateLend` / `redeem` on the same class — coming soon.
+
+Lower-level building blocks (use these for paths the class doesn't cover yet):
+- `shield(params)` / `unshield(params)` — standalone action functions
+- `AdaptProver`, `swap-e2e.ts` — full adapt-execute flow (private swap)
+- `Scanner`, `ClientMerkleTree`, `buildWallet`, `NoteStore` — client-side crypto primitives
 
 ### Prover (`packages/prover/`)
 - `TransactProver` — generates Groth16 proofs for transact (18 public inputs)

--- a/README.md
+++ b/README.md
@@ -263,6 +263,9 @@ cd examples && pnpm e2e                   # terminal 2 — runs shield → unshi
 # 6. Same e2e against devnet (uses CLI wallet + deployed programs)
 RPC_URL=https://api.devnet.solana.com pnpm --filter=@b402ai/solana-examples e2e
 
+# 6b. Same flow via the high-level SDK class (B402Solana — recommended integration path)
+RPC_URL=https://api.devnet.solana.com pnpm --filter=@b402ai/solana-examples sdk-quick
+
 # 7. Private swap on localnet (shield → adapt proof → mock adapter → unshield)
 ./ops/local-validator.sh --reset          # terminal 1
 cd examples && pnpm swap-e2e              # terminal 2

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build-deps": "pnpm --filter='@b402ai/solana-shared' --filter='@b402ai/solana-prover' --filter='@b402ai/solana' build",
     "e2e": "pnpm build-deps && tsx e2e.ts",
+    "sdk-quick": "pnpm build-deps && tsx sdk-quick.ts",
     "swap-e2e": "pnpm build-deps && tsx swap-e2e.ts",
     "swap-e2e-jupiter": "pnpm build-deps && tsx swap-e2e-jupiter.ts",
     "scanner-e2e": "pnpm build-deps && tsx scanner-e2e.ts",

--- a/examples/sdk-quick.ts
+++ b/examples/sdk-quick.ts
@@ -19,6 +19,7 @@ import { createMint, getOrCreateAssociatedTokenAccount, mintTo } from '@solana/s
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
+import { fileURLToPath } from 'node:url';
 
 import { B402Solana, instructionDiscriminator, poolConfigPda, tokenConfigPda, vaultPda } from '@b402ai/solana';
 import {
@@ -27,6 +28,7 @@ import {
 } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID } from '@solana/spl-token';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const RPC_URL = process.env.RPC_URL ?? 'https://api.devnet.solana.com';
 const POOL_ID = new PublicKey('42a3hsCXtQLWonyxWZosaaCJCweYYKMrvNd25p1Jrt2y');
 const CIRCUITS = path.resolve(__dirname, '../circuits/build');

--- a/examples/sdk-quick.ts
+++ b/examples/sdk-quick.ts
@@ -1,0 +1,103 @@
+/**
+ * Minimal integration example using the simple SDK API.
+ *
+ * Two-line shield + unshield against the deployed devnet pool. Compare to
+ * `e2e.ts` (which calls the underlying primitives directly) — this is the
+ * recommended path for app integrators.
+ *
+ * Run:
+ *   RPC_URL=https://api.devnet.solana.com pnpm --filter=@b402ai/solana-examples sdk-quick
+ *
+ * Requires:
+ *   - ~/.config/solana/id.json funded on devnet (≥ 0.5 SOL)
+ *   - circuits/build/transact_js/transact.wasm (committed)
+ *   - circuits/build/ceremony/transact_final.zkey (committed)
+ */
+
+import { Connection, Keypair, PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js';
+import { createMint, getOrCreateAssociatedTokenAccount, mintTo } from '@solana/spl-token';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+import { B402Solana, instructionDiscriminator, poolConfigPda, tokenConfigPda, vaultPda } from '@b402ai/solana';
+import {
+  ComputeBudgetProgram, SystemProgram, Transaction, TransactionInstruction,
+  sendAndConfirmTransaction,
+} from '@solana/web3.js';
+import { TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID } from '@solana/spl-token';
+
+const RPC_URL = process.env.RPC_URL ?? 'https://api.devnet.solana.com';
+const POOL_ID = new PublicKey('42a3hsCXtQLWonyxWZosaaCJCweYYKMrvNd25p1Jrt2y');
+const CIRCUITS = path.resolve(__dirname, '../circuits/build');
+
+async function main() {
+  // --- Setup: load funded CLI keypair, mint a fresh test token ---
+  const adminKey = JSON.parse(
+    fs.readFileSync(path.join(os.homedir(), '.config/solana/id.json'), 'utf8'),
+  );
+  const keypair = Keypair.fromSecretKey(new Uint8Array(adminKey));
+
+  const conn = new Connection(RPC_URL, 'confirmed');
+  console.log(`▶ wallet ${keypair.publicKey.toBase58()}`);
+  const balance = await conn.getBalance(keypair.publicKey);
+  console.log(`  balance ${(balance / LAMPORTS_PER_SOL).toFixed(3)} SOL`);
+
+  const mint = await createMint(conn, keypair, keypair.publicKey, null, 6);
+  console.log(`▶ created test mint ${mint.toBase58()}`);
+  const ata = await getOrCreateAssociatedTokenAccount(conn, keypair, mint, keypair.publicKey);
+  await mintTo(conn, keypair, mint, ata.address, keypair, 100);
+  await addTokenConfig(conn, keypair, mint);
+  console.log(`  100 minted to ATA, token_config registered`);
+
+  // --- The whole SDK integration: 4 lines ---
+  const b402 = new B402Solana({
+    cluster: 'devnet',
+    rpcUrl: RPC_URL,
+    keypair,
+    proverArtifacts: {
+      wasmPath: path.join(CIRCUITS, 'transact_js/transact.wasm'),
+      zkeyPath: path.join(CIRCUITS, 'ceremony/transact_final.zkey'),
+    },
+  });
+
+  const shieldRes = await b402.shield({ mint, amount: 100n });
+  console.log(`▶ shield ${shieldRes.signature}`);
+
+  const recipient = Keypair.generate();
+  const unshieldRes = await b402.unshield({ to: recipient.publicKey });
+  console.log(`▶ unshield ${unshieldRes.signature} → ${recipient.publicKey.toBase58()}`);
+
+  console.log(`\n✅ shield + unshield via the simple SDK API`);
+}
+
+// --- One ad-hoc helper: register the test mint with the pool. Real apps don't
+// do this; only required because we created a fresh mint for the demo. ---
+async function addTokenConfig(c: Connection, admin: Keypair, mint: PublicKey): Promise<void> {
+  const maxTvl = Buffer.alloc(8);
+  maxTvl.writeBigUInt64LE(0xFFFFFFFFFFFFFFFFn, 0);
+  const data = Buffer.concat([Buffer.from(instructionDiscriminator('add_token_config')), maxTvl]);
+  const ix = new TransactionInstruction({
+    programId: POOL_ID,
+    keys: [
+      { pubkey: admin.publicKey,                      isSigner: true,  isWritable: true  },
+      { pubkey: admin.publicKey,                      isSigner: true,  isWritable: false },
+      { pubkey: poolConfigPda(POOL_ID),               isSigner: false, isWritable: false },
+      { pubkey: tokenConfigPda(POOL_ID, mint),        isSigner: false, isWritable: true  },
+      { pubkey: mint,                                 isSigner: false, isWritable: false },
+      { pubkey: vaultPda(POOL_ID, mint),              isSigner: false, isWritable: true  },
+      { pubkey: TOKEN_PROGRAM_ID,                     isSigner: false, isWritable: false },
+      { pubkey: ASSOCIATED_TOKEN_PROGRAM_ID,          isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId,              isSigner: false, isWritable: false },
+      { pubkey: new PublicKey('SysvarRent111111111111111111111111111111111'), isSigner: false, isWritable: false },
+    ],
+    data,
+  });
+  const cu = ComputeBudgetProgram.setComputeUnitLimit({ units: 400_000 });
+  await sendAndConfirmTransaction(c, new Transaction().add(cu, ix), [admin]);
+}
+
+main().then(
+  () => process.exit(0),
+  (e) => { console.error('\n❌', e); process.exit(1); },
+);

--- a/packages/sdk/src/b402.ts
+++ b/packages/sdk/src/b402.ts
@@ -22,7 +22,11 @@ import {
   PublicKey,
   clusterApiUrl,
 } from '@solana/web3.js';
-import { getAssociatedTokenAddress } from '@solana/spl-token';
+import {
+  getAssociatedTokenAddress,
+  createAssociatedTokenAccountInstruction,
+} from '@solana/spl-token';
+import { Transaction, sendAndConfirmTransaction } from '@solana/web3.js';
 import { PROGRAM_IDS } from '@b402ai/solana-shared';
 import { TransactProver, type ProverArtifacts } from '@b402ai/solana-prover';
 import type { SpendableNote } from '@b402ai/solana-shared';
@@ -178,6 +182,23 @@ export class B402Solana {
 
     const recipientAta =
       req.recipientAta ?? (await getAssociatedTokenAddress(mint, req.to));
+
+    // Ensure the recipient ATA exists — pool's unshield enforces it must be
+    // initialized before the transfer. Idempotent: skips if already there.
+    const ataInfo = await this.connection.getAccountInfo(recipientAta);
+    if (!ataInfo) {
+      const ix = createAssociatedTokenAccountInstruction(
+        this.relayer.publicKey,
+        recipientAta,
+        req.to,
+        mint,
+      );
+      await sendAndConfirmTransaction(
+        this.connection,
+        new Transaction().add(ix),
+        [this.relayer],
+      );
+    }
 
     const poolProgramId = new PublicKey(this.programIds.b402Pool);
     const tree = await fetchTreeState(

--- a/packages/sdk/src/b402.ts
+++ b/packages/sdk/src/b402.ts
@@ -1,72 +1,114 @@
 /**
  * `B402Solana` — top-level SDK class.
  *
- * Public API mirrors `@b402ai/sdk` on EVM so apps can use the same mental
- * model. See PRD-06 §1.
+ * Two-line shield + unshield against a deployed b402 pool. The class wires
+ * keypair, prover, connection, program IDs, ATA derivation, tree fetch, and
+ * merkle proof construction internally so callers don't need to assemble the
+ * primitives themselves.
  *
- * Status note: this v0 scaffold wires the architecture — wallet, note store,
- * poseidon, merkle — but the proof-generation + tx-building pipeline
- * requires the compiled circuit artifacts (`circuits/build/`) and the
- * deployed program IDs (post-devnet-deploy). The action methods throw
- * `NotImplemented` until `@b402ai/solana-prover` is wired and the devnet
- * deploy is complete.
+ * Status:
+ *   - shield, unshield: wired against deployed devnet pool
+ *   - privateSwap, privateLend, redeem: coming soon — use
+ *     `examples/swap-e2e.ts` / `examples/kamino-adapter-fork-deposit.ts` for
+ *     the underlying flows today
+ *   - NoteStore-backed auto-discovery for unshielding old notes is in
+ *     development; the current API spends the most-recently-shielded note
+ *     by default
  */
 
-import { Connection, Keypair, PublicKey, clusterApiUrl } from '@solana/web3.js';
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  clusterApiUrl,
+} from '@solana/web3.js';
+import { getAssociatedTokenAddress } from '@solana/spl-token';
 import { PROGRAM_IDS } from '@b402ai/solana-shared';
-import type { ShieldIntent, UnshieldIntent, PrivateSwapIntent } from '@b402ai/solana-shared';
+import { TransactProver, type ProverArtifacts } from '@b402ai/solana-prover';
+import type { SpendableNote } from '@b402ai/solana-shared';
 
 import { buildWallet, type Wallet } from './wallet.js';
 import { NoteStore } from './note-store.js';
+import { shield, type ShieldResult } from './actions/shield.js';
+import { unshield, type UnshieldResult } from './actions/unshield.js';
+import { fetchTreeState } from './programs/tree-state.js';
+import { treeStatePda } from './programs/pda.js';
+import { buildZeroCache, proveMostRecentLeaf } from './merkle.js';
 import { B402Error, B402ErrorCode } from './errors.js';
 
 export interface B402SolanaConfig {
   cluster: 'mainnet' | 'devnet' | 'localnet';
+  /** Signer for shield/unshield txs. Used as depositor and (by default) as relayer. */
+  keypair: Keypair;
   rpcUrl?: string;
-  seed?: Uint8Array;
-  keypair?: Keypair;
-  relayerUrl?: string;
-  relayerFeeBps?: number;
+  /** Pre-built prover. If omitted, callers must pass `proverArtifacts`. */
+  prover?: TransactProver;
+  /** Paths to circuit wasm + zkey. Required if `prover` is not supplied. */
+  proverArtifacts?: ProverArtifacts;
+  /** Override relayer (= fee payer). Defaults to `keypair` for single-key dev. */
+  relayer?: Keypair;
   /** Optional program ID overrides (e.g. for localnet testing). */
   programIds?: Partial<typeof PROGRAM_IDS>;
+}
+
+export interface ShieldRequest {
+  mint: PublicKey;
+  amount: bigint;
+  /**
+   * Skip on-chain encrypted-note publication (~120 B saved). Safe for
+   * self-shields where the same wallet will later unshield. Default true.
+   */
+  omitEncryptedNotes?: boolean;
+}
+
+export interface UnshieldRequest {
+  /** Owner of the destination token account. */
+  to: PublicKey;
+  /** Override the destination ATA. Defaults to the canonical ATA of `to` for `mint`. */
+  recipientAta?: PublicKey;
+  /**
+   * Note to spend. Defaults to the most-recently-shielded note from this
+   * client instance.
+   */
+  note?: SpendableNote;
+  /** Mint of the note. Required if `note` is supplied; otherwise inferred from last shield. */
+  mint?: PublicKey;
 }
 
 export class B402Solana {
   readonly connection: Connection;
   readonly cluster: B402SolanaConfig['cluster'];
   readonly programIds: typeof PROGRAM_IDS;
-  readonly relayerUrl: string | undefined;
-  readonly relayerFeeBps: number;
+  readonly keypair: Keypair;
+  readonly relayer: Keypair;
 
   private _wallet: Wallet | null = null;
   private _notes: NoteStore | null = null;
-  private readonly _walletSeed: Uint8Array;
+  private _prover: TransactProver | null;
+  private _lastShield: { result: ShieldResult; mint: PublicKey } | null = null;
 
   constructor(config: B402SolanaConfig) {
     this.cluster = config.cluster;
     const rpcUrl = config.rpcUrl ?? defaultRpc(config.cluster);
     this.connection = new Connection(rpcUrl, 'confirmed');
     this.programIds = { ...PROGRAM_IDS, ...(config.programIds ?? {}) };
-    this.relayerUrl = config.relayerUrl;
-    this.relayerFeeBps = config.relayerFeeBps ?? 50;
+    this.keypair = config.keypair;
+    this.relayer = config.relayer ?? config.keypair;
 
-    if (config.seed) {
-      if (config.seed.length !== 32) {
-        throw new B402Error(B402ErrorCode.InvalidSeed, 'seed must be 32 bytes');
-      }
-      this._walletSeed = config.seed;
-    } else if (config.keypair) {
-      // Deterministic b402 seed from Solana keypair secret.
-      this._walletSeed = config.keypair.secretKey.slice(0, 32);
+    if (config.prover) {
+      this._prover = config.prover;
+    } else if (config.proverArtifacts) {
+      this._prover = new TransactProver(config.proverArtifacts);
     } else {
-      throw new B402Error(B402ErrorCode.InvalidSeed, 'seed or keypair required');
+      this._prover = null;
     }
   }
 
-  /** Lazy-initialize wallet + note store. */
+  /** Lazy-init wallet + note store. Idempotent. */
   async ready(): Promise<void> {
     if (!this._wallet) {
-      this._wallet = await buildWallet(this._walletSeed);
+      // Deterministic b402 wallet seeded from the Solana keypair's ed25519 secret.
+      this._wallet = await buildWallet(this.keypair.secretKey.slice(0, 32));
     }
     if (!this._notes) {
       this._notes = new NoteStore({
@@ -78,6 +120,117 @@ export class B402Solana {
     }
   }
 
+  /** Shield `amount` of `mint` from this caller's ATA into the pool. */
+  async shield(req: ShieldRequest): Promise<ShieldResult> {
+    await this.ready();
+    if (!this._prover) {
+      throw new B402Error(
+        B402ErrorCode.InvalidConfig,
+        'prover not initialised — pass `prover` or `proverArtifacts` to the constructor',
+      );
+    }
+
+    const depositorAta = await getAssociatedTokenAddress(
+      req.mint,
+      this.keypair.publicKey,
+    );
+
+    const result = await shield({
+      connection: this.connection,
+      poolProgramId: new PublicKey(this.programIds.b402Pool),
+      verifierProgramId: new PublicKey(this.programIds.b402VerifierTransact),
+      prover: this._prover,
+      wallet: this._wallet!,
+      mint: req.mint,
+      depositorAta,
+      depositor: this.keypair,
+      relayer: this.relayer,
+      amount: req.amount,
+      omitEncryptedNotes: req.omitEncryptedNotes,
+    });
+
+    this._lastShield = { result, mint: req.mint };
+    return result;
+  }
+
+  /**
+   * Unshield to a recipient. By default spends the most-recently-shielded
+   * note from this client instance. Pass `note` + `mint` explicitly to spend
+   * any other note (e.g. from a persisted client tree).
+   */
+  async unshield(req: UnshieldRequest): Promise<UnshieldResult> {
+    await this.ready();
+    if (!this._prover) {
+      throw new B402Error(
+        B402ErrorCode.InvalidConfig,
+        'prover not initialised — pass `prover` or `proverArtifacts` to the constructor',
+      );
+    }
+
+    const note = req.note ?? this._lastShield?.result.note;
+    const mint = req.mint ?? this._lastShield?.mint;
+    if (!note || !mint) {
+      throw new B402Error(
+        B402ErrorCode.InvalidConfig,
+        'no note to unshield — call shield() first or pass { note, mint } explicitly',
+      );
+    }
+
+    const recipientAta =
+      req.recipientAta ?? (await getAssociatedTokenAddress(mint, req.to));
+
+    const poolProgramId = new PublicKey(this.programIds.b402Pool);
+    const tree = await fetchTreeState(
+      this.connection,
+      treeStatePda(poolProgramId),
+    );
+    const zeroCache = await buildZeroCache();
+    const zeroCacheLe = zeroCache.map(bigintToLe32);
+    const rootBig = leToBigEndian(tree.currentRoot);
+    const merkleProof = proveMostRecentLeaf(
+      note.commitment,
+      note.leafIndex,
+      rootBig,
+      tree.frontier,
+      zeroCacheLe,
+    );
+
+    return unshield({
+      connection: this.connection,
+      poolProgramId,
+      verifierProgramId: new PublicKey(this.programIds.b402VerifierTransact),
+      prover: this._prover,
+      wallet: this._wallet!,
+      mint,
+      note,
+      merkleProof,
+      recipientTokenAccount: recipientAta,
+      recipientOwner: req.to,
+      relayer: this.relayer,
+    });
+  }
+
+  /** Coming soon. Use `examples/swap-e2e.ts` for the underlying flow today. */
+  async privateSwap(): Promise<never> {
+    throw new B402Error(
+      B402ErrorCode.NotImplemented,
+      'privateSwap on B402Solana coming soon — use the standalone adapt_execute path in examples/swap-e2e.ts',
+    );
+  }
+
+  /** Coming soon. Use `examples/kamino-adapter-fork-deposit.ts` for the underlying flow today. */
+  async privateLend(): Promise<never> {
+    throw new B402Error(
+      B402ErrorCode.NotImplemented,
+      'privateLend on B402Solana coming soon — use examples/kamino-adapter-fork-deposit.ts',
+    );
+  }
+
+  /** Coming soon. */
+  async redeem(): Promise<never> {
+    throw new B402Error(B402ErrorCode.NotImplemented, 'redeem coming soon');
+  }
+
   get wallet(): Wallet {
     if (!this._wallet) throw new Error('call ready() first');
     return this._wallet;
@@ -86,24 +239,6 @@ export class B402Solana {
   get notes(): NoteStore {
     if (!this._notes) throw new Error('call ready() first');
     return this._notes;
-  }
-
-  async shield(_params: Omit<ShieldIntent, 'kind'>): Promise<{ signature: string; commitment: bigint }> {
-    await this.ready();
-    throw new B402Error(
-      B402ErrorCode.NotImplemented,
-      'shield requires compiled circuit + deployed pool — see PRD-06 §2',
-    );
-  }
-
-  async unshield(_params: Omit<UnshieldIntent, 'kind'>): Promise<{ signature: string }> {
-    await this.ready();
-    throw new B402Error(B402ErrorCode.NotImplemented, 'unshield pending prover+deploy');
-  }
-
-  async privateSwap(_params: Omit<PrivateSwapIntent, 'kind'>): Promise<{ signature: string }> {
-    await this.ready();
-    throw new B402Error(B402ErrorCode.NotImplemented, 'privateSwap pending adapter+deploy');
   }
 
   async status(): Promise<{
@@ -144,4 +279,20 @@ function defaultRpc(cluster: B402SolanaConfig['cluster']): string {
 
 function uint8ToHex(u: Uint8Array): string {
   return Array.from(u).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function bigintToLe32(v: bigint): Uint8Array {
+  const buf = new Uint8Array(32);
+  let x = v;
+  for (let i = 0; i < 32; i++) {
+    buf[i] = Number(x & 0xffn);
+    x >>= 8n;
+  }
+  return buf;
+}
+
+function leToBigEndian(le: Uint8Array): bigint {
+  let v = 0n;
+  for (let i = le.length - 1; i >= 0; i--) v = (v << 8n) | BigInt(le[i]);
+  return v;
 }

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -28,4 +28,5 @@ export enum B402ErrorCode {
   InvalidRecipient         = 'INVALID_RECIPIENT',
   AmountOutOfRange         = 'AMOUNT_OUT_OF_RANGE',
   NotImplemented           = 'NOT_IMPLEMENTED',
+  InvalidConfig            = 'INVALID_CONFIG',
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -29,10 +29,17 @@ export const DomainTags = {
 
 export type DomainTagName = keyof typeof DomainTags;
 
+/**
+ * Devnet-deployed program IDs (also used as the default for mainnet alpha
+ * since the same program keypairs are used). See ops/mainnet-deploy.sh.
+ */
 export const PROGRAM_IDS = {
-  b402Pool:               'B402PooLFh4qZwRh3gkT1MkWN5z1jBTpLvZz5vE1Pool',
-  b402VerifierTransact:   'B402VrfYTrAnsCt1wBLxSxw9ZhQvA8LtQmP1VrfyTrx',
-  b402JupiterAdapter:     'B402JupTRSzWQZxNzEkR1pFsXJnKbQTp5eV1JuPAdpt',
+  b402Pool:               '42a3hsCXtQLWonyxWZosaaCJCweYYKMrvNd25p1Jrt2y',
+  b402VerifierTransact:   'Afjbnv2Ekxa98jjRw33xPPhZabevek2uZxoE75kr6ZrK',
+  b402VerifierAdapt:      '3Y2tyhNSaUiW5AcZcmFGRyTMdnroxHxc5GqFQPcMTZae',
+  b402JupiterAdapter:     '3RHRcbinCmcj8JPBfVxb9FW76oh4r8y21aSx4JFy3yx7',
+  b402KaminoAdapter:      '2enwFgcGKJDqruHpCtvmhtxe3DYcV3k72VTvoGcdt2rX',
+  b402MockAdapter:        '89kw33YDcbXfiayVNauz599LaDm51EuU8amWydpjYKgp',
 } as const;
 
 export const JUPITER_V6_PROGRAM_ID = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4';


### PR DESCRIPTION
## What

Two-line integration surface for the common path. The `B402Solana` class now hides:

- wallet build (deterministic from the Solana keypair's ed25519 secret)
- prover instantiation (caller passes circuit paths once)
- depositor ATA derivation
- on-chain tree-state fetch
- merkle proof construction (`proveMostRecentLeaf` against the on-chain frontier — single-shot most-recent-shielded-note path)
- relayer wiring (defaults to the same keypair for single-key dev mode; override via `config.relayer` for separate fee-payer)

## Caller code

```ts
import { B402Solana } from '@b402ai/solana';

const b402 = new B402Solana({
  cluster: 'devnet',
  keypair,
  proverArtifacts: {
    wasmPath: 'circuits/build/transact_js/transact.wasm',
    zkeyPath: 'circuits/build/ceremony/transact_final.zkey',
  },
});

await b402.shield({ mint, amount: 100n });
await b402.unshield({ to: recipientPubkey });
```

## Scope

- `shield`, `unshield`: wired against the deployed devnet pool
- `privateSwap`, `privateLend`, `redeem`: throw with a pointer to the existing working examples (`swap-e2e.ts`, `kamino-adapter-fork-deposit.ts`) — wiring those into the class is on the SDK roadmap

## Files

- `packages/sdk/src/b402.ts` — class implementation
- `packages/sdk/src/errors.ts` — new `B402ErrorCode.InvalidConfig`
- `examples/sdk-quick.ts` — runnable end-to-end example
- `examples/package.json` — `pnpm sdk-quick` script
- `README.md` §SDK — updated to point at the new entry-point with a code block

## Test plan

- [x] `pnpm --filter='@b402ai/solana' typecheck`
- [x] `pnpm --filter='@b402ai/solana' test` (vitest)
- [ ] `RPC_URL=https://api.devnet.solana.com pnpm --filter=@b402ai/solana-examples sdk-quick` against deployed devnet pool
- [ ] CI green (typecheck + sdk-tests + crypto-rust + workspace-clippy)