### PR TITLE
sdk: B402Solana.privateSwap end-to-end against deployed adapter bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ ENGINEER-REVIEW.md
 # Sub-agent scratch
 .copilot-out/
 docs/LAUNCH-DRAFTS.md
+
+# Engineering spikes — throwaway design docs, runbooks, exploratory PRDs.
+# Spikes that mature into committed work get promoted to docs/prds/PRD-NN-...md.
+docs/spikes/

--- a/examples/package.json
+++ b/examples/package.json
@@ -10,6 +10,7 @@
     "build-deps": "pnpm --filter='@b402ai/solana-shared' --filter='@b402ai/solana-prover' --filter='@b402ai/solana' build",
     "e2e": "pnpm build-deps && tsx e2e.ts",
     "sdk-quick": "pnpm build-deps && tsx sdk-quick.ts",
+    "sdk-quick-swap": "pnpm build-deps && tsx sdk-quick-swap.ts",
     "swap-e2e": "pnpm build-deps && tsx swap-e2e.ts",
     "swap-e2e-jupiter": "pnpm build-deps && tsx swap-e2e-jupiter.ts",
     "scanner-e2e": "pnpm build-deps && tsx scanner-e2e.ts",

--- a/examples/sdk-quick-swap.ts
+++ b/examples/sdk-quick-swap.ts
@@ -1,0 +1,272 @@
+/**
+ * sdk-quick-swap — TDD test for B402Solana.privateSwap.
+ *
+ * Two assertions, in order:
+ *   RED 1: calling privateSwap() with no shielded balance must throw with
+ *          B402ErrorCode.NoSpendableNotes (code 'NO_SPENDABLE_NOTES').
+ *   GREEN: shield → privateSwap → unshield to fresh recipient succeeds with
+ *          three real devnet sigs and outAmount == 250 (mock adapter mints
+ *          a deterministic 2.5x of the 100-unit input).
+ *
+ * Run:
+ *   RPC_URL=https://api.devnet.solana.com pnpm --filter='@b402ai/solana-examples' sdk-quick-swap
+ *
+ * Pre-conditions:
+ *   - ~/.config/solana/id.json funded on devnet (>= 1 SOL)
+ *   - circuits/build/{transact_js/transact.wasm, ceremony/transact_final.zkey,
+ *                     adapt_js/adapt.wasm, ceremony/adapt_final.zkey} present
+ */
+
+import {
+  AddressLookupTableProgram, ComputeBudgetProgram, Connection, Keypair, PublicKey, SystemProgram,
+  Transaction, TransactionInstruction, sendAndConfirmTransaction,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+import {
+  TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID,
+  createMint, getOrCreateAssociatedTokenAccount, mintTo,
+} from '@solana/spl-token';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+import {
+  B402Solana, B402Error, B402ErrorCode,
+  instructionDiscriminator,
+  poolConfigPda, treeStatePda, adapterRegistryPda, treasuryPda,
+  tokenConfigPda, vaultPda,
+} from '@b402ai/solana';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const RPC_URL = process.env.RPC_URL ?? 'https://api.devnet.solana.com';
+const POOL_ID         = new PublicKey('42a3hsCXtQLWonyxWZosaaCJCweYYKMrvNd25p1Jrt2y');
+const VERIFIER_T_ID   = new PublicKey('Afjbnv2Ekxa98jjRw33xPPhZabevek2uZxoE75kr6ZrK');
+const VERIFIER_A_ID   = new PublicKey('3Y2tyhNSaUiW5AcZcmFGRyTMdnroxHxc5GqFQPcMTZae');
+const MOCK_ADAPTER_ID = new PublicKey('89kw33YDcbXfiayVNauz599LaDm51EuU8amWydpjYKgp');
+const SYSVAR_RENT     = new PublicKey('SysvarRent111111111111111111111111111111111');
+const CIRCUITS        = path.resolve(__dirname, '../circuits/build');
+const EXECUTE_DISC    = instructionDiscriminator('execute');
+
+async function main() {
+  console.log(`▶ RPC ${RPC_URL}`);
+  const connection = new Connection(RPC_URL, 'confirmed');
+
+  // Admin = CLI wallet (the devnet pool's admin_multisig). Alice = fresh user.
+  const adminPath = process.env.ADMIN_KEYPAIR
+    ?? path.join(os.homedir(), '.config/solana/id.json');
+  const admin = Keypair.fromSecretKey(
+    new Uint8Array(JSON.parse(fs.readFileSync(adminPath, 'utf8'))),
+  );
+  const alice = Keypair.generate();
+
+  // Fund alice from admin (devnet airdrop is rate-limited; admin already has SOL).
+  // 0.18 SOL: 2 × 0.07 SOL nullifier-shard rent + recipient ATA + tx fees.
+  const fundIx = SystemProgram.transfer({
+    fromPubkey: admin.publicKey,
+    toPubkey: alice.publicKey,
+    lamports: 0.18 * LAMPORTS_PER_SOL,
+  });
+  await sendAndConfirmTransaction(connection, new Transaction().add(fundIx), [admin]);
+  const aliceBal = await connection.getBalance(alice.publicKey);
+  console.log(`▶ alice ${alice.publicKey.toBase58().slice(0, 8)}… (${(aliceBal / LAMPORTS_PER_SOL).toFixed(3)} SOL)`);
+
+  // --- Admin setup (out of SDK scope; lifted from swap-e2e.ts) ---
+  const inMint  = await createMint(connection, admin, admin.publicKey, null, 6);
+  const outMint = await createMint(connection, admin, admin.publicKey, null, 9);
+  console.log(`▶ in_mint=${inMint.toBase58().slice(0,8)}…  out_mint=${outMint.toBase58().slice(0,8)}…`);
+
+  await addTokenConfig(connection, admin, inMint);
+  await addTokenConfig(connection, admin, outMint);
+  await registerAdapter(connection, admin, MOCK_ADAPTER_ID);
+
+  // Alice's IN ATA, mint 100 in_mint to her.
+  const aliceInAta = await getOrCreateAssociatedTokenAccount(connection, admin, inMint, alice.publicKey);
+  await mintTo(connection, admin, inMint, aliceInAta.address, admin, 100);
+
+  // Adapter scratch ATAs + pre-fund adapter_out_ta with 100,000 out_mint
+  // (mock adapter is constant-rate; this is just inventory the test consumes).
+  const adapterAuthority = PublicKey.findProgramAddressSync(
+    [new TextEncoder().encode('b402/v1'), new TextEncoder().encode('adapter')],
+    MOCK_ADAPTER_ID,
+  )[0];
+  const adapterInTa  = await getOrCreateAssociatedTokenAccount(connection, admin, inMint,  adapterAuthority, true);
+  const adapterOutTa = await getOrCreateAssociatedTokenAccount(connection, admin, outMint, adapterAuthority, true);
+  await mintTo(connection, admin, outMint, adapterOutTa.address, admin, 100_000);
+  console.log(`▶ adapter scratch TAs ready, adapter_out_ta pre-funded`);
+
+  // Per-run ALT: fresh mints' vault PDAs aren't in the canonical b402 ALT.
+  // Production callers using USDC/wSOL won't need this.
+  const alt = await createTestAlt(connection, admin, [
+    poolConfigPda(POOL_ID),
+    adapterRegistryPda(POOL_ID),
+    vaultPda(POOL_ID, outMint),
+    treeStatePda(POOL_ID),
+    VERIFIER_A_ID,
+    MOCK_ADAPTER_ID,
+    adapterAuthority,
+    adapterInTa.address,
+    adapterOutTa.address,
+    aliceInAta.address,
+    TOKEN_PROGRAM_ID,
+    SystemProgram.programId,
+  ]);
+  console.log(`▶ ALT ${alt.toBase58().slice(0, 8)}…`);
+
+  // --- Build B402Solana around alice ---
+  const b402 = new B402Solana({
+    cluster: 'devnet',
+    rpcUrl: RPC_URL,
+    keypair: alice,
+    proverArtifacts: {
+      wasmPath: path.join(CIRCUITS, 'transact_js/transact.wasm'),
+      zkeyPath: path.join(CIRCUITS, 'ceremony/transact_final.zkey'),
+    },
+    adaptProverArtifacts: {
+      wasmPath: path.join(CIRCUITS, 'adapt_js/adapt.wasm'),
+      zkeyPath: path.join(CIRCUITS, 'ceremony/adapt_final.zkey'),
+    },
+  });
+
+  // === RED 1: privateSwap before any shield must throw NoSpendableNotes ===
+  let red1Threw = false;
+  let red1Code: string | undefined;
+  try {
+    await b402.privateSwap({
+      inMint, outMint, amount: 100n,
+      adapterProgramId: MOCK_ADAPTER_ID,
+      adapterInTa: adapterInTa.address,
+      adapterOutTa: adapterOutTa.address,
+      alt,
+    });
+  } catch (e) {
+    red1Threw = true;
+    red1Code = (e instanceof B402Error) ? e.code : undefined;
+  }
+  if (!red1Threw) throw new Error('RED 1 failed: privateSwap with no shielded balance did not throw');
+  if (red1Code !== B402ErrorCode.NoSpendableNotes) {
+    throw new Error(`RED 1 failed: expected code NO_SPENDABLE_NOTES, got ${red1Code}`);
+  }
+  console.log(`▶ RED 1 ✓ privateSwap before shield → ${red1Code}`);
+
+  // === GREEN: shield then privateSwap ===
+  console.log(`▶ shielding 100 in_mint…`);
+  const shieldRes = await b402.shield({ mint: inMint, amount: 100n });
+  console.log(`  shield ${shieldRes.signature}`);
+
+  console.log(`▶ privateSwap 100 in_mint → out_mint via mock adapter…`);
+  const swapRes = await b402.privateSwap({
+    inMint, outMint, amount: 100n,
+    adapterProgramId: MOCK_ADAPTER_ID,
+    adapterInTa: adapterInTa.address,
+    adapterOutTa: adapterOutTa.address,
+    alt,
+  });
+  console.log(`  swap   ${swapRes.signature}`);
+  console.log(`  outAmount = ${swapRes.outAmount}`);
+  if (swapRes.signature.length < 32) throw new Error('expected swap signature');
+  if (swapRes.outAmount !== 200n) {
+    throw new Error(`expected outAmount=200 (mock adapter constant-rate), got ${swapRes.outAmount}`);
+  }
+
+  // Unshield the output note to a fresh recipient.
+  const recipient = Keypair.generate();
+  console.log(`▶ unshield 200 out_mint → ${recipient.publicKey.toBase58().slice(0, 8)}…`);
+  const unshieldRes = await b402.unshield({
+    note: swapRes.outNote,
+    mint: outMint,
+    to: recipient.publicKey,
+  });
+  console.log(`  unshield ${unshieldRes.signature}`);
+  if (unshieldRes.signature.length < 32) throw new Error('expected unshield signature');
+
+  console.log('');
+  console.log('✅ shield → privateSwap → unshield via the SDK class');
+  console.log(`   shield   ${shieldRes.signature}`);
+  console.log(`   swap     ${swapRes.signature}`);
+  console.log(`   unshield ${unshieldRes.signature}`);
+}
+
+// ---------------------------------------------------------------------------
+// Admin helpers — lifted from swap-e2e.ts. Out of SDK scope (privileged ops).
+// ---------------------------------------------------------------------------
+
+async function addTokenConfig(c: Connection, admin: Keypair, mint: PublicKey): Promise<void> {
+  const existing = await c.getAccountInfo(tokenConfigPda(POOL_ID, mint));
+  if (existing) return;
+  const maxTvl = Buffer.alloc(8);
+  maxTvl.writeBigUInt64LE(0xFFFFFFFFFFFFFFFFn, 0);
+  const data = Buffer.concat([
+    Buffer.from(instructionDiscriminator('add_token_config')),
+    maxTvl,
+  ]);
+  const ix = new TransactionInstruction({
+    programId: POOL_ID,
+    keys: [
+      { pubkey: admin.publicKey,                      isSigner: true,  isWritable: true  },
+      { pubkey: admin.publicKey,                      isSigner: true,  isWritable: false },
+      { pubkey: poolConfigPda(POOL_ID),               isSigner: false, isWritable: false },
+      { pubkey: tokenConfigPda(POOL_ID, mint),        isSigner: false, isWritable: true  },
+      { pubkey: mint,                                 isSigner: false, isWritable: false },
+      { pubkey: vaultPda(POOL_ID, mint),              isSigner: false, isWritable: true  },
+      { pubkey: TOKEN_PROGRAM_ID,                     isSigner: false, isWritable: false },
+      { pubkey: ASSOCIATED_TOKEN_PROGRAM_ID,          isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId,              isSigner: false, isWritable: false },
+      { pubkey: SYSVAR_RENT,                          isSigner: false, isWritable: false },
+    ],
+    data,
+  });
+  const cu = ComputeBudgetProgram.setComputeUnitLimit({ units: 400_000 });
+  await sendAndConfirmTransaction(c, new Transaction().add(cu, ix), [admin]);
+}
+
+async function registerAdapter(c: Connection, admin: Keypair, adapterId: PublicKey): Promise<void> {
+  const data = Buffer.concat([
+    Buffer.from(instructionDiscriminator('register_adapter')),
+    adapterId.toBuffer(),
+    Buffer.from([1, 0, 0, 0]),
+    Buffer.from(EXECUTE_DISC),
+  ]);
+  const ix = new TransactionInstruction({
+    programId: POOL_ID,
+    keys: [
+      { pubkey: admin.publicKey,             isSigner: true,  isWritable: true  },
+      { pubkey: poolConfigPda(POOL_ID),      isSigner: false, isWritable: false },
+      { pubkey: adapterRegistryPda(POOL_ID), isSigner: false, isWritable: true  },
+      { pubkey: SystemProgram.programId,     isSigner: false, isWritable: false },
+    ],
+    data,
+  });
+  try {
+    await sendAndConfirmTransaction(c, new Transaction().add(ix), [admin]);
+  } catch (e: any) {
+    const msg = e.message ?? String(e);
+    if (msg.includes('AdapterAlreadyRegistered') || msg.includes('already in use')) return;
+    throw e;
+  }
+}
+
+async function createTestAlt(
+  c: Connection,
+  payer: Keypair,
+  addresses: PublicKey[],
+): Promise<PublicKey> {
+  const slot = await c.getSlot('finalized');
+  const [createIx, alt] = AddressLookupTableProgram.createLookupTable({
+    authority: payer.publicKey,
+    payer: payer.publicKey,
+    recentSlot: slot,
+  });
+  await sendAndConfirmTransaction(c, new Transaction().add(createIx), [payer]);
+  const extendIx = AddressLookupTableProgram.extendLookupTable({
+    payer: payer.publicKey,
+    authority: payer.publicKey,
+    lookupTable: alt,
+    addresses,
+  });
+  await sendAndConfirmTransaction(c, new Transaction().add(extendIx), [payer]);
+  await new Promise((r) => setTimeout(r, 500));
+  return alt;
+}
+
+main().then(() => process.exit(0), (e) => { console.error('\n❌', e); process.exit(1); });

--- a/packages/sdk/src/b402.ts
+++ b/packages/sdk/src/b402.ts
@@ -17,27 +17,53 @@
  */
 
 import {
+  AddressLookupTableAccount,
+  ComputeBudgetProgram,
   Connection,
   Keypair,
   PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
   clusterApiUrl,
+  sendAndConfirmTransaction,
 } from '@solana/web3.js';
 import {
+  TOKEN_PROGRAM_ID,
   getAssociatedTokenAddress,
   createAssociatedTokenAccountInstruction,
 } from '@solana/spl-token';
-import { Transaction, sendAndConfirmTransaction } from '@solana/web3.js';
-import { PROGRAM_IDS } from '@b402ai/solana-shared';
-import { TransactProver, type ProverArtifacts } from '@b402ai/solana-prover';
+import { keccak_256 } from '@noble/hashes/sha3';
+import { randomBytes as nodeRandomBytes } from 'node:crypto';
+import { FR_MODULUS, PROGRAM_IDS, leToFrReduced } from '@b402ai/solana-shared';
 import type { SpendableNote } from '@b402ai/solana-shared';
+import {
+  AdaptProver,
+  TransactProver,
+  type AdaptWitness,
+  type ProverArtifacts,
+} from '@b402ai/solana-prover';
 
 import { buildWallet, type Wallet } from './wallet.js';
 import { NoteStore } from './note-store.js';
 import { shield, type ShieldResult } from './actions/shield.js';
 import { unshield, type UnshieldResult } from './actions/unshield.js';
 import { fetchTreeState } from './programs/tree-state.js';
-import { treeStatePda } from './programs/pda.js';
+import {
+  adapterRegistryPda,
+  nullifierShardPda,
+  poolConfigPda,
+  shardPrefix,
+  tokenConfigPda,
+  treeStatePda,
+  vaultPda,
+} from './programs/pda.js';
+import { instructionDiscriminator, concat, u16Le, u32Le, u64Le, vecU8 } from './programs/anchor.js';
 import { buildZeroCache, proveMostRecentLeaf } from './merkle.js';
+import { commitmentHash, feeBindHash, nullifierHash, poseidonTagged } from './poseidon.js';
+import { encryptNote } from './note-encryption.js';
 import { B402Error, B402ErrorCode } from './errors.js';
 
 export interface B402SolanaConfig {
@@ -45,10 +71,14 @@ export interface B402SolanaConfig {
   /** Signer for shield/unshield txs. Used as depositor and (by default) as relayer. */
   keypair: Keypair;
   rpcUrl?: string;
-  /** Pre-built prover. If omitted, callers must pass `proverArtifacts`. */
+  /** Pre-built transact prover. If omitted, callers must pass `proverArtifacts`. */
   prover?: TransactProver;
-  /** Paths to circuit wasm + zkey. Required if `prover` is not supplied. */
+  /** Paths to transact circuit wasm + zkey. Required if `prover` is not supplied. */
   proverArtifacts?: ProverArtifacts;
+  /** Pre-built adapt prover. If omitted, `adaptProverArtifacts` builds one lazily. */
+  adaptProver?: AdaptProver;
+  /** Paths to adapt circuit wasm + zkey. Required for `privateSwap` / `privateLend`. */
+  adaptProverArtifacts?: ProverArtifacts;
   /** Override relayer (= fee payer). Defaults to `keypair` for single-key dev. */
   relayer?: Keypair;
   /** Optional program ID overrides (e.g. for localnet testing). */
@@ -63,6 +93,45 @@ export interface ShieldRequest {
    * self-shields where the same wallet will later unshield. Default true.
    */
   omitEncryptedNotes?: boolean;
+}
+
+export interface PrivateSwapRequest {
+  /** SPL mint of the IN token (must be in a shielded note this client owns). */
+  inMint: PublicKey;
+  /** SPL mint of the OUT token (will be reshielded into a new note). */
+  outMint: PublicKey;
+  /** Amount of `inMint` to swap, in smallest units. */
+  amount: bigint;
+  /** Adapter program ID. Defaults to `programIds.b402JupiterAdapter`. */
+  adapterProgramId?: PublicKey;
+  /** Adapter-side scratch ATA for IN mint, owned by the adapter PDA. */
+  adapterInTa: PublicKey;
+  /** Adapter-side scratch ATA for OUT mint, owned by the adapter PDA. */
+  adapterOutTa: PublicKey;
+  /** Address Lookup Table to compress the account-meta list. Required to fit
+   *  the v0 tx under Solana's 1,232 B cap. Defaults to the b402 ALT for the
+   *  configured cluster — supply your own for tests with fresh mints. */
+  alt?: PublicKey;
+  /** Expected output amount, in smallest units of `outMint`. Bound into the proof.
+   *  Defaults to `amount` × 2 for the mock adapter (constant 2x). For real
+   *  adapters the caller should pass a quote-based number. */
+  expectedOut?: bigint;
+  /** Optional raw adapter instruction data. Defaults to the mock-adapter
+   *  shape: discriminator + amount + expected_out + 8-byte action_payload. */
+  adapterIxData?: Uint8Array;
+  /** Optional action payload (Borsh-encoded adapter action). Defaults to
+   *  8 zero bytes (mock adapter delta=0). */
+  actionPayload?: Uint8Array;
+  /** Optional override for which note to spend. Defaults to the most-recently-shielded note in `inMint`. */
+  note?: SpendableNote;
+}
+
+export interface PrivateSwapResult {
+  signature: string;
+  /** New shielded note in `outMint`. */
+  outNote: SpendableNote;
+  /** Out-vault delta observed on-chain post-swap. */
+  outAmount: bigint;
 }
 
 export interface UnshieldRequest {
@@ -89,6 +158,7 @@ export class B402Solana {
   private _wallet: Wallet | null = null;
   private _notes: NoteStore | null = null;
   private _prover: TransactProver | null;
+  private _adaptProver: AdaptProver | null;
   private _lastShield: { result: ShieldResult; mint: PublicKey } | null = null;
 
   constructor(config: B402SolanaConfig) {
@@ -105,6 +175,14 @@ export class B402Solana {
       this._prover = new TransactProver(config.proverArtifacts);
     } else {
       this._prover = null;
+    }
+
+    if (config.adaptProver) {
+      this._adaptProver = config.adaptProver;
+    } else if (config.adaptProverArtifacts) {
+      this._adaptProver = new AdaptProver(config.adaptProverArtifacts);
+    } else {
+      this._adaptProver = null;
     }
   }
 
@@ -231,12 +309,279 @@ export class B402Solana {
     });
   }
 
-  /** Coming soon. Use `examples/swap-e2e.ts` for the underlying flow today. */
-  async privateSwap(): Promise<never> {
-    throw new B402Error(
-      B402ErrorCode.NotImplemented,
-      'privateSwap on B402Solana coming soon — use the standalone adapt_execute path in examples/swap-e2e.ts',
+  /**
+   * Shielded swap through a registered adapter. Burns one input note in
+   * `inMint`, CPIs the adapter, and reshields the proceeds into a new note
+   * in `outMint`. All atomic in a single v0 transaction.
+   */
+  async privateSwap(req: PrivateSwapRequest): Promise<PrivateSwapResult> {
+    await this.ready();
+    if (!this._prover) {
+      throw new B402Error(
+        B402ErrorCode.InvalidConfig,
+        'transact prover not initialised — pass `prover` or `proverArtifacts` to the constructor',
+      );
+    }
+    if (!this._adaptProver) {
+      throw new B402Error(
+        B402ErrorCode.InvalidConfig,
+        'adapt prover not initialised — pass `adaptProver` or `adaptProverArtifacts` to the constructor',
+      );
+    }
+    if (req.amount <= 0n) {
+      throw new B402Error(B402ErrorCode.AmountOutOfRange, 'amount must be > 0');
+    }
+
+    // 1. Find the note to spend.
+    const inMintFr = leToFrReduced(req.inMint.toBytes());
+    const note: SpendableNote | undefined =
+      req.note ??
+      (this._lastShield && this._lastShield.mint.equals(req.inMint)
+        ? this._lastShield.result.note
+        : undefined);
+    if (!note) {
+      throw new B402Error(
+        B402ErrorCode.NoSpendableNotes,
+        `no shielded note in ${req.inMint.toBase58().slice(0, 8)}…; call shield() first or pass { note }`,
+      );
+    }
+    if (note.value < req.amount) {
+      throw new B402Error(
+        B402ErrorCode.InsufficientBalance,
+        `note has ${note.value} units but swap requested ${req.amount}`,
+      );
+    }
+
+    const adapterProgramId =
+      req.adapterProgramId ?? new PublicKey(this.programIds.b402JupiterAdapter);
+    const adapterId = leToFrReduced(keccak_256(adapterProgramId.toBytes()) as Uint8Array);
+    const actionPayload = req.actionPayload ?? new Uint8Array(8);
+    const payloadKeccakFr = leToFrReduced(keccak_256(actionPayload) as Uint8Array);
+
+    const expectedOut = req.expectedOut ?? req.amount * 2n;
+    const outMintFr = leToFrReduced(req.outMint.toBytes());
+    const actionHash = await poseidonTagged('adaptBind', payloadKeccakFr, outMintFr);
+
+    // 2. Tree state + merkle proof for the input note.
+    const poolProgramId = new PublicKey(this.programIds.b402Pool);
+    const tree = await fetchTreeState(this.connection, treeStatePda(poolProgramId));
+    const zeroCache = await buildZeroCache();
+    const zeroCacheLe = zeroCache.map(bigintToLe32);
+    const rootBig = leToBigEndian(tree.currentRoot);
+    const merkleProof = proveMostRecentLeaf(
+      note.commitment,
+      note.leafIndex,
+      rootBig,
+      tree.frontier,
+      zeroCacheLe,
     );
+
+    // 3. Build output note (single non-dummy out commitment).
+    const outRandom = leToFrReduced(new Uint8Array(nodeRandomBytes(32)));
+    const outCommitment = await commitmentHash(
+      outMintFr,
+      expectedOut,
+      outRandom,
+      this._wallet!.spendingPub,
+    );
+    const encryptedOut = await encryptNote(
+      {
+        tokenMint: outMintFr,
+        value: expectedOut,
+        random: outRandom,
+        spendingPub: this._wallet!.spendingPub,
+      },
+      this._wallet!.viewingPub,
+      tree.leafCount,
+    );
+
+    // 4. Nullifier + shard prefixes.
+    const nullifierVal = await nullifierHash(this._wallet!.spendingPriv, note.leafIndex);
+    const nullifierLe = bigintToLe32(nullifierVal);
+    const nullPrefix = shardPrefix(nullifierLe);
+    const dummyPrefix = (nullPrefix + 1) & 0xffff;
+
+    // 5. Witness.
+    const feeBind = await feeBindHash(0n, 0n);
+    const recipientBindVal = await poseidonTagged('recipientBind', 0n, 0n);
+    const witness: AdaptWitness = {
+      merkleRoot: rootBig,
+      nullifier: [nullifierVal, 0n],
+      commitmentOut: [outCommitment, 0n],
+      publicAmountIn: req.amount,
+      publicAmountOut: 0n,
+      publicTokenMint: inMintFr,
+      relayerFee: 0n,
+      relayerFeeBind: feeBind,
+      rootBind: 0n,
+      recipientBind: recipientBindVal,
+      commitTag: domainTagFr('b402/v1/commit'),
+      nullTag: domainTagFr('b402/v1/null'),
+      mkNodeTag: domainTagFr('b402/v1/mk-node'),
+      spendKeyPubTag: domainTagFr('b402/v1/spend-key-pub'),
+      feeBindTag: domainTagFr('b402/v1/fee-bind'),
+      recipientBindTag: domainTagFr('b402/v1/recipient-bind'),
+      adapterId,
+      actionHash,
+      expectedOutValue: expectedOut,
+      expectedOutMint: outMintFr,
+      adaptBindTag: domainTagFr('b402/v1/adapt-bind'),
+      inTokenMint: [inMintFr, 0n],
+      inValue: [note.value, 0n],
+      inRandom: [note.random, 0n],
+      inSpendingPriv: [this._wallet!.spendingPriv, 1n],
+      inLeafIndex: [note.leafIndex, 0n],
+      inSiblings: [merkleProof.siblings, zeroCache.slice(0, 26)],
+      inPathBits: [merkleProof.pathBits, Array(26).fill(0)],
+      inIsDummy: [0, 1],
+      outValue: [expectedOut, 0n],
+      outRandom: [outRandom, 0n],
+      outSpendingPub: [this._wallet!.spendingPub, 0n],
+      outIsDummy: [0, 1],
+      relayerFeeRecipient: 0n,
+      recipientOwnerLow: 0n,
+      recipientOwnerHigh: 0n,
+      actionPayloadKeccakFr: payloadKeccakFr,
+    };
+
+    // 6. Generate the adapt proof.
+    const proof = await this._adaptProver.prove(witness);
+
+    // 7. Adapter ix data: default mock-adapter shape (discriminator + amount +
+    //    expected_out + Vec<u8> action_payload). Caller can override for real
+    //    adapters whose execute() takes a different layout.
+    const executeDisc = instructionDiscriminator('execute');
+    const adapterIxData =
+      req.adapterIxData ??
+      concat(executeDisc, u64Le(req.amount), u64Le(expectedOut), vecU8(actionPayload));
+
+    // 8. Adapter authority + relayer-fee sentinel ATA. Fee is 0 here so the
+    //    handler skips the owner check, but Anchor still wants a TokenAccount
+    //    in that slot.
+    const adapterAuthority = PublicKey.findProgramAddressSync(
+      [new TextEncoder().encode('b402/v1'), new TextEncoder().encode('adapter')],
+      adapterProgramId,
+    )[0];
+    const feeAtaSentinel = await getAssociatedTokenAddress(req.inMint, this.relayer.publicKey);
+
+    // 9. Pool ix data — adapt_execute layout.
+    const poolIxData = concat(
+      instructionDiscriminator('adapt_execute'),
+      vecU8(proof.proofBytes),
+      proof.publicInputsLeBytes[0], // merkle_root
+      proof.publicInputsLeBytes[1], // nullifier[0]
+      proof.publicInputsLeBytes[2], // nullifier[1]
+      proof.publicInputsLeBytes[3], // commitment_out[0]
+      proof.publicInputsLeBytes[4], // commitment_out[1]
+      u64Le(req.amount),
+      u64Le(0n),
+      req.inMint.toBytes(),
+      u64Le(0n), // relayer_fee
+      proof.publicInputsLeBytes[9], // relayer_fee_bind
+      proof.publicInputsLeBytes[10], // root_bind
+      proof.publicInputsLeBytes[11], // recipient_bind
+      proof.publicInputsLeBytes[18], // adapter_id
+      proof.publicInputsLeBytes[19], // action_hash
+      u64Le(expectedOut),
+      req.outMint.toBytes(),
+      u32Le(0), // encrypted_notes vec len = 0 (omit on-chain to save bytes)
+      new Uint8Array([0b10]), // in_dummy_mask (slot 0 real, slot 1 dummy)
+      new Uint8Array([0b10]), // out_dummy_mask
+      u16Le(nullPrefix),
+      u16Le(dummyPrefix),
+      this.relayer.publicKey.toBytes(),
+      vecU8(adapterIxData),
+      vecU8(actionPayload),
+    );
+
+    const shardPda0 = nullifierShardPda(poolProgramId, nullPrefix);
+    const shardPda1 = nullifierShardPda(poolProgramId, dummyPrefix);
+
+    const poolIxKeys = [
+      { pubkey: this.relayer.publicKey, isSigner: true, isWritable: true },
+      { pubkey: poolConfigPda(poolProgramId), isSigner: false, isWritable: false },
+      { pubkey: adapterRegistryPda(poolProgramId), isSigner: false, isWritable: false },
+      { pubkey: tokenConfigPda(poolProgramId, req.inMint), isSigner: false, isWritable: false },
+      { pubkey: tokenConfigPda(poolProgramId, req.outMint), isSigner: false, isWritable: false },
+      { pubkey: vaultPda(poolProgramId, req.inMint), isSigner: false, isWritable: true },
+      { pubkey: vaultPda(poolProgramId, req.outMint), isSigner: false, isWritable: true },
+      { pubkey: treeStatePda(poolProgramId), isSigner: false, isWritable: true },
+      { pubkey: new PublicKey(this.programIds.b402VerifierAdapt), isSigner: false, isWritable: false },
+      { pubkey: adapterProgramId, isSigner: false, isWritable: false },
+      { pubkey: adapterAuthority, isSigner: false, isWritable: false },
+      { pubkey: req.adapterInTa, isSigner: false, isWritable: true },
+      { pubkey: req.adapterOutTa, isSigner: false, isWritable: true },
+      { pubkey: feeAtaSentinel, isSigner: false, isWritable: true },
+      { pubkey: shardPda0, isSigner: false, isWritable: true },
+      { pubkey: shardPda1, isSigner: false, isWritable: true },
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ];
+    const poolIx = new TransactionInstruction({
+      programId: poolProgramId,
+      keys: poolIxKeys,
+      data: Buffer.from(poolIxData),
+    });
+    const cuIx = ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 });
+
+    // 10. Resolve ALT (caller-supplied or cluster default).
+    const altPubkey = req.alt;
+    if (!altPubkey) {
+      throw new B402Error(
+        B402ErrorCode.InvalidConfig,
+        'privateSwap currently requires an explicit `alt` PublicKey — fresh test mints need a per-run ALT; production mints will use the b402 ALT once issue #N lands',
+      );
+    }
+    const altInfo = await this.connection.getAddressLookupTable(altPubkey);
+    if (!altInfo.value) {
+      throw new B402Error(B402ErrorCode.InvalidConfig, `ALT ${altPubkey.toBase58()} not found`);
+    }
+    const lookupTable: AddressLookupTableAccount = altInfo.value;
+
+    // 11. Pre-swap out-vault snapshot for outAmount calc.
+    const outVaultPda = vaultPda(poolProgramId, req.outMint);
+    const preInfo = await this.connection.getAccountInfo(outVaultPda);
+    const preOut = preInfo ? readSplAmount(preInfo.data) : 0n;
+
+    // 12. v0 tx.
+    const blockhash = (await this.connection.getLatestBlockhash('confirmed')).blockhash;
+    const msg = new TransactionMessage({
+      payerKey: this.relayer.publicKey,
+      recentBlockhash: blockhash,
+      instructions: [cuIx, poolIx],
+    }).compileToV0Message([lookupTable]);
+    const vtx = new VersionedTransaction(msg);
+    vtx.sign([this.relayer]);
+
+    const signature = await this.connection.sendRawTransaction(vtx.serialize(), {
+      skipPreflight: true,
+      preflightCommitment: 'confirmed',
+    });
+    await this.connection.confirmTransaction(
+      { signature, blockhash, lastValidBlockHeight: (await this.connection.getLatestBlockhash()).lastValidBlockHeight },
+      'confirmed',
+    );
+
+    // 13. Compute outAmount from on-chain delta.
+    const postInfo = await this.connection.getAccountInfo(outVaultPda);
+    const postOut = postInfo ? readSplAmount(postInfo.data) : 0n;
+    const outAmount = postOut - preOut;
+
+    // 14. Build the SpendableNote for the new output.
+    const outNote: SpendableNote = {
+      tokenMint: outMintFr,
+      value: expectedOut,
+      random: outRandom,
+      spendingPub: this._wallet!.spendingPub,
+      spendingPriv: this._wallet!.spendingPriv,
+      commitment: outCommitment,
+      leafIndex: tree.leafCount,
+      encryptedBytes: encryptedOut.ciphertext,
+      ephemeralPub: encryptedOut.ephemeralPub,
+      viewingTag: encryptedOut.viewingTag,
+    };
+
+    return { signature, outNote, outAmount };
   }
 
   /** Coming soon. Use `examples/kamino-adapter-fork-deposit.ts` for the underlying flow today. */
@@ -316,4 +661,17 @@ function leToBigEndian(le: Uint8Array): bigint {
   let v = 0n;
   for (let i = le.length - 1; i >= 0; i--) v = (v << 8n) | BigInt(le[i]);
   return v;
+}
+
+/** Domain-tag UTF-8 → big-endian-as-int → mod p (matches packages/crypto). */
+function domainTagFr(tag: string): bigint {
+  let acc = 0n;
+  for (let i = 0; i < tag.length; i++) acc = (acc << 8n) | BigInt(tag.charCodeAt(i));
+  return acc % FR_MODULUS;
+}
+
+/** SPL Token-account amount lives at bytes [64..72] little-endian u64. */
+function readSplAmount(data: Buffer | Uint8Array): bigint {
+  const buf = data instanceof Buffer ? data : Buffer.from(data);
+  return buf.readBigUInt64LE(64);
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,11 @@
 export { B402Solana } from './b402.js';
-export type { B402SolanaConfig } from './b402.js';
+export type {
+  B402SolanaConfig,
+  ShieldRequest,
+  UnshieldRequest,
+  PrivateSwapRequest,
+  PrivateSwapResult,
+} from './b402.js';
 export { B402Error, B402ErrorCode } from './errors.js';
 export { buildWallet, type Wallet } from './wallet.js';
 export { ClientMerkleTree, buildZeroCache, proveMostRecentLeaf, type MerkleProof } from './merkle.js';


### PR DESCRIPTION
## What

`B402Solana.privateSwap()` no longer throws — it lifts the `adapt_execute` path from `examples/swap-e2e.ts` into the high-level SDK class. Callers now do **shield → privateSwap → unshield** in three method calls instead of assembling the witness, proof, ix data, and v0 tx themselves.

```ts
const b402 = new B402Solana({
  cluster: 'devnet',
  keypair,
  proverArtifacts:      { wasmPath, zkeyPath },          // transact circuit
  adaptProverArtifacts: { wasmPath, zkeyPath },          // adapt circuit
});

await b402.shield({ mint: USDC, amount: 100n });
const swap = await b402.privateSwap({
  inMint: USDC, outMint: WSOL, amount: 100n,
  adapterProgramId, adapterInTa, adapterOutTa, alt,
});
await b402.unshield({ note: swap.outNote, mint: WSOL, to: recipient });
```

## TDD

`examples/sdk-quick-swap.ts` covers both cases:

- **RED 1**: `privateSwap` without a prior shield asserts `code === NoSpendableNotes` (was throwing `NotImplemented` pre-implementation)
- **GREEN**: shield → privateSwap → unshield to a fresh recipient produces three real devnet sigs and `outAmount === 200n` (mock adapter's constant 2x)

Verified end-to-end against deployed bytecode:
- Shield: [`2p5Lr7Wq…3VS4v`](https://explorer.solana.com/tx/2p5Lr7WqWoD9LcjVLY9WDbQUqzAgFoYZJzNFSZ2fAw5nZc1sU8Z5xuxMfMeWmp3LBhK4fQuNMEXe4bkiDPa3VS4v?cluster=devnet)
- Swap: [`22J1o4j6…7fiN`](https://explorer.solana.com/tx/22J1o4j6X8UNfzBRP6UK1aVYZPBWLCTcbTWJPNUfRxamJHCLYJskRH8M6mPovfv2hsRbb8zXiLTYJeVq3Wgm7fiN?cluster=devnet)
- Unshield: [`3jndZEu7…CP13o`](https://explorer.solana.com/tx/3jndZEu7gabmu1FrzVXyww5SA6Xc4MXwZcDBP7bVBi8HLMv2CSkFd7wNteoxReuByiN22LcZmDn3oV8A5DTCP13o?cluster=devnet)

## Diff scope

| File | LoC |
|---|---|
| `packages/sdk/src/b402.ts` | +380 (privateSwap impl + types + helpers) |
| `examples/sdk-quick-swap.ts` | +272 (TDD test, lifts admin setup from swap-e2e.ts) |
| `packages/sdk/src/index.ts` | +6 (type re-exports) |
| `examples/package.json` | +1 (`pnpm sdk-quick-swap` script) |
| `.gitignore` | +4 (`docs/spikes/` for throwaway design docs) |

## Caveats flagged honestly in the commit body

- `alt: PublicKey` is required today. Fresh test mints aren't in the production b402 ALT; production callers using USDC/wSOL will use the cluster-default once the lookup helper lands (small follow-up).
- `expectedOut` defaults to `amount × 2n` (mock-adapter rate). Real adapters need a quote-based number; caller passes via the optional override.
- `adapterIxData` defaults to mock-adapter shape. Jupiter adapter integration will ship its own builder that the SDK can consume.

## Test plan
- [x] SDK + examples typecheck clean
- [x] `RPC_URL=https://api.devnet.solana.com pnpm sdk-quick-swap` produces three real devnet sigs and ✅
- [ ] CI green (typecheck + sdk-tests + crypto-rust + workspace-clippy)

## Out of scope (separate issues)
- B402Solana.privateLend (Layer 2 of the spike — separate branch + PR)
- MCP server wrapping B402Solana (Layer 3)
- CLI (Layer 4)