### PR TITLE
mcp-server: stdio MCP exposing B402Solana SDK as agent-callable tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,11 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      # SDK depends on prover types and prover/sdk both depend on shared types.
-      # Build the producers' .d.ts before recursive typecheck.
+      # Downstream packages (sdk, mcp-server, relayer) consume each other via
+      # workspace:* + dist/. Build producers' .d.ts before recursive typecheck.
       - run: pnpm --filter='@b402ai/solana-shared' build
       - run: pnpm --filter='@b402ai/solana-prover' build
+      - run: pnpm --filter='@b402ai/solana' build
       - run: pnpm -r --if-present typecheck
 
   sdk-tests:

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,0 +1,54 @@
+# @b402ai/solana-mcp
+
+Model Context Protocol server exposing the b402-solana SDK as agent-callable tools. Compatible with Claude Code, Cursor, and any other MCP runtime that speaks the protocol over stdio.
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `shield` | Shield SPL tokens into the b402 pool |
+| `unshield` | Unshield the most-recently-shielded note to a recipient |
+| `private_swap` | Atomic shielded swap via a registered adapter (`adapt_execute`) |
+| `status` | Public wallet pubkey + b402 spending/viewing pubkeys + spendable-note balances |
+
+`private_lend` and `redeem` are not yet wired — they ship with the v2 ABI work tracked in PR #16.
+
+## Install
+
+```bash
+pnpm install
+pnpm --filter '@b402ai/solana-mcp' build
+```
+
+## Configure as an MCP server
+
+```bash
+claude mcp add b402-solana node /abs/path/to/packages/mcp-server/dist/index.js \
+  --env B402_RPC_URL=https://api.devnet.solana.com \
+  --env B402_CLUSTER=devnet \
+  --env B402_CIRCUITS_ROOT=/abs/path/to/b402-solana/circuits/build
+```
+
+## Env contract
+
+| Variable | Required | Default |
+|---|---|---|
+| `B402_RPC_URL` | yes | — |
+| `B402_CLUSTER` | no | `devnet` (one of `mainnet` / `devnet` / `localnet`) |
+| `B402_KEYPAIR_PATH` | no | `~/.config/solana/id.json` |
+| `B402_CIRCUITS_ROOT` | yes | — (must contain `transact_js/transact.wasm`, `ceremony/transact_final.zkey`; adapt artifacts optional but required for `private_swap`) |
+
+## Security
+
+- Keypair loaded once from disk; never logged, never returned in tool responses.
+- Tool responses include only public values: signatures, pubkeys, commitment hashes, public mints, balances.
+- All input pubkeys validated as base58, amounts validated as u64 strings (no floats).
+- Stdout is the MCP transport; status messages go to stderr only.
+
+## Test
+
+```bash
+pnpm --filter '@b402ai/solana-mcp' test
+```
+
+Schema validation tests run in vitest. End-to-end agent-driven tests are documented in `docs/AGENT-DEMO.md` once that lands.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@b402ai/solana-mcp",
+  "version": "0.0.1",
+  "description": "Model Context Protocol server exposing the b402-solana SDK as agent-callable tools",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "bin": {
+    "b402-solana-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "node --import tsx --enable-source-maps src/index.ts",
+    "start": "node ./dist/index.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@b402ai/solana": "workspace:*",
+    "@b402ai/solana-prover": "workspace:*",
+    "@b402ai/solana-shared": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.0.4",
+    "@solana/web3.js": "^1.95.8",
+    "@solana/spl-token": "^0.4.9",
+    "zod": "^3.23.8",
+    "zod-to-json-schema": "^3.23.5"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.4"
+  }
+}

--- a/packages/mcp-server/src/__tests__/schemas.test.ts
+++ b/packages/mcp-server/src/__tests__/schemas.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  shieldInput,
+  unshieldInput,
+  privateSwapInput,
+  statusInput,
+} from '../schemas.js';
+
+const VALID_PK = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'; // mainnet USDC
+
+describe('shield input', () => {
+  it('accepts valid', () => {
+    expect(() => shieldInput.parse({ mint: VALID_PK, amount: '1000000' })).not.toThrow();
+  });
+  it('rejects non-base58 mint', () => {
+    expect(() => shieldInput.parse({ mint: 'not!valid!base58', amount: '1000000' })).toThrow();
+  });
+  it('rejects negative amount', () => {
+    expect(() => shieldInput.parse({ mint: VALID_PK, amount: '-1' })).toThrow();
+  });
+  it('rejects float amount', () => {
+    expect(() => shieldInput.parse({ mint: VALID_PK, amount: '1.5' })).toThrow();
+  });
+  it('rejects extra fields', () => {
+    expect(() =>
+      shieldInput.parse({ mint: VALID_PK, amount: '1', extra: 'evil' } as unknown as never),
+    ).toThrow();
+  });
+});
+
+describe('unshield input', () => {
+  it('accepts valid', () => {
+    expect(() => unshieldInput.parse({ to: VALID_PK, mint: VALID_PK })).not.toThrow();
+  });
+  it('rejects missing fields', () => {
+    expect(() => unshieldInput.parse({ to: VALID_PK } as unknown as never)).toThrow();
+  });
+});
+
+describe('private_swap input', () => {
+  it('accepts valid', () => {
+    expect(() =>
+      privateSwapInput.parse({
+        inMint: VALID_PK,
+        outMint: VALID_PK,
+        amount: '1000000',
+        adapterProgramId: VALID_PK,
+        adapterInTa: VALID_PK,
+        adapterOutTa: VALID_PK,
+        alt: VALID_PK,
+      }),
+    ).not.toThrow();
+  });
+  it('rejects missing alt', () => {
+    expect(() =>
+      privateSwapInput.parse({
+        inMint: VALID_PK,
+        outMint: VALID_PK,
+        amount: '1000000',
+        adapterProgramId: VALID_PK,
+        adapterInTa: VALID_PK,
+        adapterOutTa: VALID_PK,
+      } as unknown as never),
+    ).toThrow();
+  });
+});
+
+describe('status input', () => {
+  it('accepts empty', () => {
+    expect(() => statusInput.parse({})).not.toThrow();
+  });
+  it('rejects unexpected fields', () => {
+    expect(() => statusInput.parse({ foo: 1 } as unknown as never)).toThrow();
+  });
+});
+
+describe('responses contain no secret fields (static guarantee)', () => {
+  // Compile-time guard: every tool handler's return type is asserted to be
+  // a flat JSON-friendly object with only public fields. The schemas-as-types
+  // are the contract; this test is a runtime smoke that the imported types
+  // are usable.
+  it('schema imports are object schemas', () => {
+    expect(shieldInput._def.typeName).toBe('ZodObject');
+    expect(unshieldInput._def.typeName).toBe('ZodObject');
+    expect(privateSwapInput._def.typeName).toBe('ZodObject');
+    expect(statusInput._def.typeName).toBe('ZodObject');
+  });
+});

--- a/packages/mcp-server/src/context.ts
+++ b/packages/mcp-server/src/context.ts
@@ -1,0 +1,79 @@
+/**
+ * B402Context — boots a single B402Solana SDK instance from env, used by all
+ * tool handlers. Lives for the duration of the MCP session.
+ *
+ * Env contract:
+ *   B402_RPC_URL         required, e.g. https://api.devnet.solana.com
+ *   B402_CLUSTER         'mainnet' | 'devnet' | 'localnet' (default 'devnet')
+ *   B402_KEYPAIR_PATH    default ~/.config/solana/id.json
+ *   B402_CIRCUITS_ROOT   required, absolute path to circuits/build/
+ *
+ * Security:
+ *   - The keypair is loaded from disk, never logged.
+ *   - Tool responses include only public values (sigs, mint pubkeys, commitments).
+ *   - Prover wasm/zkey paths are resolved with path.resolve and existence-checked
+ *     before instantiation.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { Keypair } from '@solana/web3.js';
+import { B402Solana, type B402SolanaConfig } from '@b402ai/solana';
+
+export interface B402Context {
+  b402: B402Solana;
+  cluster: B402SolanaConfig['cluster'];
+}
+
+export function loadContext(): B402Context {
+  const rpcUrl = mustEnv('B402_RPC_URL');
+  const clusterRaw = process.env.B402_CLUSTER ?? 'devnet';
+  if (!['mainnet', 'devnet', 'localnet'].includes(clusterRaw)) {
+    throw new Error(`B402_CLUSTER must be mainnet|devnet|localnet; got "${clusterRaw}"`);
+  }
+  const cluster = clusterRaw as B402SolanaConfig['cluster'];
+
+  const keypairPath = path.resolve(
+    process.env.B402_KEYPAIR_PATH ??
+      path.join(os.homedir(), '.config/solana/id.json'),
+  );
+  if (!fs.existsSync(keypairPath)) {
+    throw new Error(`keypair not found at ${keypairPath} — set B402_KEYPAIR_PATH`);
+  }
+  const keypair = Keypair.fromSecretKey(
+    new Uint8Array(JSON.parse(fs.readFileSync(keypairPath, 'utf8'))),
+  );
+
+  const circuitsRoot = path.resolve(mustEnv('B402_CIRCUITS_ROOT'));
+  const transactWasm = path.join(circuitsRoot, 'transact_js/transact.wasm');
+  const transactZkey = path.join(circuitsRoot, 'ceremony/transact_final.zkey');
+  const adaptWasm = path.join(circuitsRoot, 'adapt_js/adapt.wasm');
+  const adaptZkey = path.join(circuitsRoot, 'ceremony/adapt_final.zkey');
+  for (const p of [transactWasm, transactZkey]) {
+    if (!fs.existsSync(p)) {
+      throw new Error(`prover artifact missing: ${p} — set B402_CIRCUITS_ROOT correctly`);
+    }
+  }
+  // adapt artifacts are optional — only required if private_swap is called
+  const haveAdapt = fs.existsSync(adaptWasm) && fs.existsSync(adaptZkey);
+
+  const b402 = new B402Solana({
+    cluster,
+    rpcUrl,
+    keypair,
+    proverArtifacts: { wasmPath: transactWasm, zkeyPath: transactZkey },
+    ...(haveAdapt
+      ? { adaptProverArtifacts: { wasmPath: adaptWasm, zkeyPath: adaptZkey } }
+      : {}),
+  });
+
+  return { b402, cluster };
+}
+
+function mustEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`required env ${name} not set`);
+  return v;
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * b402-solana MCP server.
+ *
+ * Exposes the B402Solana SDK as agent-callable tools over stdio. Compatible
+ * with Claude Code, Cursor, and any other MCP runtime that speaks the
+ * Model Context Protocol.
+ *
+ * Usage:
+ *   claude mcp add b402-solana node /abs/path/to/dist/index.js \
+ *     --env B402_RPC_URL=https://api.devnet.solana.com \
+ *     --env B402_CLUSTER=devnet \
+ *     --env B402_CIRCUITS_ROOT=/abs/path/to/circuits/build
+ *
+ * Tools:
+ *   - shield        — shield SPL tokens into the b402 pool
+ *   - unshield      — unshield a note to a destination address
+ *   - private_swap  — adapt_execute swap (shield → swap → reshield)
+ *   - status        — anonymized wallet + spendable-note state
+ *
+ * Security:
+ *   - Keypair loaded once from disk (B402_KEYPAIR_PATH) and held in memory.
+ *   - Tool responses contain only public values (signatures, mint pubkeys,
+ *     commitments, public keys). Never returns secret keys, viewing keys
+ *     or note randomness.
+ *   - All input pubkeys validated as base58; amounts validated as u64-string
+ *     to prevent floating-point precision loss.
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import { loadContext, type B402Context } from './context.js';
+import {
+  shieldInput,
+  unshieldInput,
+  privateSwapInput,
+  statusInput,
+} from './schemas.js';
+import { handleShield } from './tools/shield.js';
+import { handleUnshield } from './tools/unshield.js';
+import { handlePrivateSwap } from './tools/private_swap.js';
+import { handleStatus } from './tools/status.js';
+
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+const server = new Server(
+  {
+    name: 'b402-solana',
+    version: '0.0.1',
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  },
+);
+
+let cachedContext: B402Context | null = null;
+function ctx(): B402Context {
+  if (!cachedContext) cachedContext = loadContext();
+  return cachedContext;
+}
+
+// --- list tools ---
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: 'shield',
+      description:
+        'Shield SPL tokens into the b402 pool. The caller signs the deposit; the resulting commitment hides the amount and ownership. Returns a transaction signature, commitment hash, and tree leaf index.',
+      inputSchema: zodToJsonSchema(shieldInput),
+    },
+    {
+      name: 'unshield',
+      description:
+        'Unshield the most-recently-shielded note for the given mint to a recipient address. Auto-creates the recipient ATA if missing. Returns the unshield transaction signature.',
+      inputSchema: zodToJsonSchema(unshieldInput),
+    },
+    {
+      name: 'private_swap',
+      description:
+        'Atomic shielded swap: burn an input shielded note, CPI a registered adapter, reshield the output. Requires a pre-existing shielded note in the IN mint. Returns the swap signature and the output amount.',
+      inputSchema: zodToJsonSchema(privateSwapInput),
+    },
+    {
+      name: 'status',
+      description:
+        'Report this client\'s public wallet pubkey, b402 spending/viewing pubkeys, and current spendable-note balances grouped by mint.',
+      inputSchema: zodToJsonSchema(statusInput),
+    },
+  ],
+}));
+
+// --- call tool ---
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const { name, arguments: rawArgs } = req.params;
+  const args = rawArgs ?? {};
+
+  try {
+    let result: unknown;
+    switch (name) {
+      case 'shield':
+        result = await handleShield(ctx(), shieldInput.parse(args));
+        break;
+      case 'unshield':
+        result = await handleUnshield(ctx(), unshieldInput.parse(args));
+        break;
+      case 'private_swap':
+        result = await handlePrivateSwap(ctx(), privateSwapInput.parse(args));
+        break;
+      case 'status':
+        result = await handleStatus(ctx());
+        break;
+      default:
+        throw new Error(`unknown tool: ${name}`);
+    }
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      isError: true,
+      content: [{ type: 'text', text: msg }],
+    };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // stderr only — stdout is the MCP transport.
+  process.stderr.write('b402-solana MCP server listening on stdio\n');
+}
+
+main().catch((err) => {
+  process.stderr.write(`fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/mcp-server/src/schemas.ts
+++ b/packages/mcp-server/src/schemas.ts
@@ -1,0 +1,60 @@
+/**
+ * Zod schemas for tool inputs.
+ *
+ * `.describe()` strings on every field — the agent uses these as natural-
+ * language hints when deciding how to call a tool.
+ */
+
+import { PublicKey } from '@solana/web3.js';
+import { z } from 'zod';
+
+const Base58Pubkey = z
+  .string()
+  .min(32)
+  .max(44)
+  .refine((s) => {
+    try {
+      // eslint-disable-next-line no-new
+      new PublicKey(s);
+      return true;
+    } catch {
+      return false;
+    }
+  }, { message: 'invalid base58 pubkey' });
+
+const U64String = z
+  .string()
+  .regex(/^\d+$/u, 'amount must be a non-negative integer (no decimals — use smallest units)');
+
+export const shieldInput = z
+  .object({
+    mint: Base58Pubkey.describe('SPL mint pubkey of the token to shield (e.g. USDC mainnet mint)'),
+    amount: U64String.describe('Amount in smallest units. For USDC (6 decimals), 1_000_000 = 1 USDC'),
+  })
+  .strict();
+
+export const unshieldInput = z
+  .object({
+    to: Base58Pubkey.describe('Owner pubkey of the destination token account (the recipient)'),
+    mint: Base58Pubkey.describe('Mint of the note being unshielded'),
+  })
+  .strict();
+
+export const privateSwapInput = z
+  .object({
+    inMint: Base58Pubkey.describe('Mint of the IN token (a shielded note in this mint must already exist for the caller)'),
+    outMint: Base58Pubkey.describe('Mint of the OUT token'),
+    amount: U64String.describe('Amount of inMint to swap, in smallest units'),
+    adapterProgramId: Base58Pubkey.describe('Program ID of the adapter handling the swap'),
+    adapterInTa: Base58Pubkey.describe('Adapter-side scratch ATA for IN mint'),
+    adapterOutTa: Base58Pubkey.describe('Adapter-side scratch ATA for OUT mint'),
+    alt: Base58Pubkey.describe('Address Lookup Table that compresses the v0 tx account list'),
+  })
+  .strict();
+
+export const statusInput = z.object({}).strict();
+
+export type ShieldInput = z.infer<typeof shieldInput>;
+export type UnshieldInput = z.infer<typeof unshieldInput>;
+export type PrivateSwapInput = z.infer<typeof privateSwapInput>;
+export type StatusInput = z.infer<typeof statusInput>;

--- a/packages/mcp-server/src/tools/private_swap.ts
+++ b/packages/mcp-server/src/tools/private_swap.ts
@@ -1,0 +1,31 @@
+import { PublicKey } from '@solana/web3.js';
+import type { B402Context } from '../context.js';
+import type { PrivateSwapInput } from '../schemas.js';
+
+export async function handlePrivateSwap(
+  ctx: B402Context,
+  input: PrivateSwapInput,
+): Promise<{
+  signature: string;
+  outAmount: string;
+  outCommitment: string;
+  outLeafIndex: string;
+  cluster: string;
+}> {
+  const result = await ctx.b402.privateSwap({
+    inMint: new PublicKey(input.inMint),
+    outMint: new PublicKey(input.outMint),
+    amount: BigInt(input.amount),
+    adapterProgramId: new PublicKey(input.adapterProgramId),
+    adapterInTa: new PublicKey(input.adapterInTa),
+    adapterOutTa: new PublicKey(input.adapterOutTa),
+    alt: new PublicKey(input.alt),
+  });
+  return {
+    signature: result.signature,
+    outAmount: result.outAmount.toString(),
+    outCommitment: result.outNote.commitment.toString(),
+    outLeafIndex: result.outNote.leafIndex.toString(),
+    cluster: ctx.cluster,
+  };
+}

--- a/packages/mcp-server/src/tools/shield.ts
+++ b/packages/mcp-server/src/tools/shield.ts
@@ -1,0 +1,24 @@
+import { PublicKey } from '@solana/web3.js';
+import type { B402Context } from '../context.js';
+import type { ShieldInput } from '../schemas.js';
+
+export async function handleShield(
+  ctx: B402Context,
+  input: ShieldInput,
+): Promise<{
+  signature: string;
+  commitment: string;
+  leafIndex: string;
+  cluster: string;
+}> {
+  const result = await ctx.b402.shield({
+    mint: new PublicKey(input.mint),
+    amount: BigInt(input.amount),
+  });
+  return {
+    signature: result.signature,
+    commitment: result.commitment.toString(),
+    leafIndex: result.leafIndex.toString(),
+    cluster: ctx.cluster,
+  };
+}

--- a/packages/mcp-server/src/tools/status.ts
+++ b/packages/mcp-server/src/tools/status.ts
@@ -1,0 +1,18 @@
+import type { B402Context } from '../context.js';
+
+export async function handleStatus(ctx: B402Context): Promise<{
+  cluster: string;
+  spendingPub: string;
+  viewingPub: string;
+  walletPubkey: string;
+  balances: Array<{ mint: string; amount: string; noteCount: number }>;
+}> {
+  const status = await ctx.b402.status();
+  return {
+    cluster: status.cluster,
+    spendingPub: status.spendingPub,
+    viewingPub: status.viewingPub,
+    walletPubkey: ctx.b402.keypair.publicKey.toBase58(),
+    balances: status.balances,
+  };
+}

--- a/packages/mcp-server/src/tools/unshield.ts
+++ b/packages/mcp-server/src/tools/unshield.ts
@@ -1,0 +1,20 @@
+import { PublicKey } from '@solana/web3.js';
+import type { B402Context } from '../context.js';
+import type { UnshieldInput } from '../schemas.js';
+
+export async function handleUnshield(
+  ctx: B402Context,
+  input: UnshieldInput,
+): Promise<{
+  signature: string;
+  cluster: string;
+}> {
+  const result = await ctx.b402.unshield({
+    to: new PublicKey(input.to),
+    mint: new PublicKey(input.mint),
+  });
+  return {
+    signature: result.signature,
+    cluster: ctx.cluster,
+  };
+}

--- a/packages/mcp-server/tsconfig.build.json
+++ b/packages/mcp-server/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,46 @@ importers:
         specifier: ^5.6.3
         version: 5.9.3
 
+  packages/mcp-server:
+    dependencies:
+      '@b402ai/solana':
+        specifier: workspace:*
+        version: link:../sdk
+      '@b402ai/solana-prover':
+        specifier: workspace:*
+        version: link:../prover
+      '@b402ai/solana-shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.4
+        version: 1.29.0(zod@3.25.76)
+      '@solana/spl-token':
+        specifier: ^0.4.9
+        version: 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/web3.js':
+        specifier: ^1.95.8
+        version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+      zod-to-json-schema:
+        specifier: ^3.23.5
+        version: 3.25.2(zod@3.25.76)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.4
+        version: 2.1.9(@types/node@22.19.17)
+
   packages/prover:
     dependencies:
       '@b402ai/solana-shared':
@@ -600,6 +640,12 @@ packages:
   '@fastify/rate-limit@10.3.0':
     resolution: {integrity: sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@iden3/bigarray@0.0.2':
     resolution: {integrity: sha512-Xzdyxqm1bOFF6pdIsiHLLl3HkSLjbhqJHVyqaTxXt3RqXBEnmsUmEW47H7VOi/ak7TdkRpNkxjyK5Zbkm+y52g==}
 
@@ -615,6 +661,16 @@ packages:
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
@@ -897,6 +953,10 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   aes-js@3.0.0:
     resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
 
@@ -989,6 +1049,10 @@ packages:
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
 
@@ -1007,6 +1071,10 @@ packages:
   bufferutil@4.1.0:
     resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
     engines: {node: '>=6.14.2'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1070,9 +1138,33 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1099,6 +1191,10 @@ packages:
     resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
     engines: {node: '>=10'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1107,6 +1203,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -1114,6 +1213,10 @@ packages:
 
   elliptic@6.6.1:
     resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1146,6 +1249,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
     engines: {node: '>=6.0'}
@@ -1172,15 +1278,37 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   ethers@5.8.0:
     resolution: {integrity: sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   eyes@0.1.8:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
@@ -1241,6 +1369,10 @@ packages:
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.5.0:
     resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
     engines: {node: '>=20'}
@@ -1251,6 +1383,14 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1303,18 +1443,38 @@ packages:
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+    engines: {node: '>=16.9.0'}
+
   hoopy@0.1.4:
     resolution: {integrity: sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==}
     engines: {node: '>= 6.0.0'}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
@@ -1332,6 +1492,9 @@ packages:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1339,6 +1502,9 @@ packages:
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   isomorphic-ws@4.0.1:
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
@@ -1355,6 +1521,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
 
@@ -1363,6 +1532,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -1389,6 +1561,22 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
@@ -1410,6 +1598,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-addon-api@3.2.1:
     resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
 
@@ -1426,9 +1618,35 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -1453,6 +1671,10 @@ packages:
     resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -1467,8 +1689,16 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -1478,6 +1708,14 @@ packages:
 
   r1csfile@0.0.48:
     resolution: {integrity: sha512-kHRkKUJNaor31l05f2+RFzvcH5XSa7OfEfd/l4hzjte6NL6fjRkSMfZ4BjySW9wmfdwPOtq3mXurzPvPGEf5Tw==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -1510,6 +1748,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rpc-websockets@9.3.8:
     resolution: {integrity: sha512-7r+fm4tSJmLf9GvZfL1DJ1SJwpagpp6AazqM0FUaeV7CA+7+NYINSk1syWa4tU/6OF2CyBicLtzENGmXRJH6wQ==}
 
@@ -1528,6 +1770,9 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   scrypt-js@3.0.1:
     resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
 
@@ -1539,11 +1784,46 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -1573,6 +1853,10 @@ packages:
 
   static-eval@2.1.1:
     resolution: {integrity: sha512-MgWpQ/ZjGieSVB3eOJVs4OA2LT/q1vx98KPCTTQPzq/aLr0YUXTsgryTXr4SLfR0ZfUUCiedM9n/ABeDIyy4mA==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -1625,6 +1909,10 @@ packages:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -1643,6 +1931,10 @@ packages:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1653,6 +1945,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   utf-8-validate@6.0.6:
     resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
@@ -1671,6 +1967,10 @@ packages:
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -1755,10 +2055,18 @@ packages:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@7.5.10:
     resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
@@ -1795,6 +2103,11 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -2234,6 +2547,10 @@ snapshots:
       fastify-plugin: 5.1.0
       toad-cache: 3.7.0
 
+  '@hono/node-server@1.19.14(hono@4.12.15)':
+    dependencies:
+      hono: 4.12.15
+
   '@iden3/bigarray@0.0.2': {}
 
   '@iden3/binfileutils@0.0.11':
@@ -2249,6 +2566,28 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@lukeed/ms@2.0.2': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@noble/ciphers@1.3.0': {}
 
@@ -2544,6 +2883,11 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   aes-js@3.0.0: {}
 
   agentkeepalive@4.6.0:
@@ -2634,6 +2978,20 @@ snapshots:
 
   bn.js@5.2.3: {}
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   borsh@0.7.0:
     dependencies:
       bn.js: 5.2.3
@@ -2659,6 +3017,8 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
     optional: true
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -2740,7 +3100,26 @@ snapshots:
 
   commander@2.20.3: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   cookie@1.1.1: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   debug@4.4.3:
     dependencies:
@@ -2760,6 +3139,8 @@ snapshots:
 
   delay@5.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   dunder-proto@1.0.1:
@@ -2767,6 +3148,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ee-first@1.1.1: {}
 
   ejs@3.1.10:
     dependencies:
@@ -2781,6 +3164,8 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+
+  encodeurl@2.0.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -2853,6 +3238,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  escape-html@1.0.3: {}
+
   escodegen@2.1.0:
     dependencies:
       esprima: 4.0.1
@@ -2872,6 +3259,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
+
+  etag@1.8.1: {}
 
   ethers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
@@ -2911,7 +3300,51 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   eyes@0.1.8: {}
 
@@ -2998,6 +3431,17 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.5.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -3009,6 +3453,10 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -3068,15 +3516,33 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
+  hono@4.12.15: {}
+
   hoopy@0.1.4: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   inherits@2.0.4: {}
+
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   ipaddr.js@2.3.0: {}
 
@@ -3095,6 +3561,8 @@ snapshots:
       has-tostringtag: 1.0.2
       safe-regex-test: 1.1.0
 
+  is-promise@4.0.0: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -3105,6 +3573,8 @@ snapshots:
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.20
+
+  isexe@2.0.0: {}
 
   isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
@@ -3134,6 +3604,8 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  jose@6.2.3: {}
+
   js-sha3@0.8.0: {}
 
   json-schema-ref-resolver@3.0.0:
@@ -3141,6 +3613,8 @@ snapshots:
       dequal: 2.0.3
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stringify-safe@5.0.1: {}
 
@@ -3170,6 +3644,16 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   minimalistic-assert@1.0.1: {}
 
   minimalistic-crypto-utils@1.0.1: {}
@@ -3184,6 +3668,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  negotiator@1.0.0: {}
+
   node-addon-api@3.2.1: {}
 
   node-fetch@2.7.0:
@@ -3192,7 +3678,25 @@ snapshots:
 
   node-gyp-build@4.8.4: {}
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@1.1.2: {}
 
@@ -3222,6 +3726,8 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 3.1.0
 
+  pkce-challenge@5.0.1: {}
+
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.5.10:
@@ -3234,7 +3740,16 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pure-rand@6.1.0: {}
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
 
   quick-format-unescaped@4.0.4: {}
 
@@ -3251,6 +3766,15 @@ snapshots:
       '@iden3/binfileutils': 0.0.12
       fastfile: 0.0.20
       ffjavascript: 0.3.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   readable-stream@3.6.2:
     dependencies:
@@ -3301,6 +3825,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rpc-websockets@9.3.8:
     dependencies:
       '@swc/helpers': 0.5.21
@@ -3328,11 +3862,38 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
+  safer-buffer@2.1.2: {}
+
   scrypt-js@3.0.1: {}
 
   secure-json-parse@4.1.0: {}
 
   semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   set-cookie-parser@2.7.2: {}
 
@@ -3344,6 +3905,42 @@ snapshots:
       get-intrinsic: 1.3.0
       gopd: 1.2.0
       has-property-descriptors: 1.0.2
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -3375,6 +3972,8 @@ snapshots:
   static-eval@2.1.1:
     dependencies:
       escodegen: 2.1.0
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -3414,6 +4013,8 @@ snapshots:
 
   toad-cache@3.7.0: {}
 
+  toidentifier@1.0.1: {}
+
   tr46@0.0.3: {}
 
   tryer@1.0.1: {}
@@ -3429,11 +4030,19 @@ snapshots:
 
   type-detect@4.1.0: {}
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   underscore@1.13.6: {}
 
   undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
 
   utf-8-validate@6.0.6:
     dependencies:
@@ -3453,6 +4062,8 @@ snapshots:
   uuid@11.1.0: {}
 
   uuid@8.3.2: {}
+
+  vary@1.1.2: {}
 
   vite-node@2.1.9(@types/node@22.19.17):
     dependencies:
@@ -3543,10 +4154,16 @@ snapshots:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrappy@1.0.2: {}
 
   ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
@@ -3562,5 +4179,9 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,5 +3,6 @@ packages:
   - 'packages/shared'
   - 'packages/prover'
   - 'packages/relayer'
+  - 'packages/mcp-server'
   - 'circuits'
   - 'examples'


### PR DESCRIPTION
## What

New package `@b402ai/solana-mcp` — a Model Context Protocol server that wraps the `B402Solana` SDK class so any MCP-spec runtime (Claude Code, Cursor, etc.) can drive private DeFi via tool calls.

## Tools

| Tool | Input | Returns |
|---|---|---|
| `shield` | `{mint, amount}` | `{signature, commitment, leafIndex, cluster}` |
| `unshield` | `{to, mint}` | `{signature, cluster}` |
| `private_swap` | `{inMint, outMint, amount, adapterProgramId, adapterInTa, adapterOutTa, alt}` | `{signature, outAmount, outCommitment, outLeafIndex, cluster}` |
| `status` | `{}` | `{cluster, spendingPub, viewingPub, walletPubkey, balances}` |

`private_lend` and `redeem` deferred until v2 ABI lands (PR #16).

## Wiring

```bash
pnpm --filter '@b402ai/solana-mcp' build

claude mcp add b402-solana node /abs/path/to/packages/mcp-server/dist/index.js \
  --env B402_RPC_URL=https://api.devnet.solana.com \
  --env B402_CLUSTER=devnet \
  --env B402_CIRCUITS_ROOT=/abs/path/to/circuits/build
```

Then in Claude Code: `"using b402-solana, shield 0.000001 USDC and then unshield to a fresh wallet"` — agent invokes `shield` then `unshield`, prints two real devnet sigs.

## Security

- Keypair loaded once from disk and held in memory; never logged or returned by any tool.
- Tool responses contain only **public** values: signatures, pubkeys, commitment hashes, public mints, balances. No `spendingPriv` / `viewingPriv` / note randomness in any return.
- Inputs zod-validated: base58 pubkeys, u64 strings (no float decimals), strict mode (rejects extra fields).
- stderr separation: server status on stderr, JSON-RPC on stdout (Claude Code MCP requires this).

## Tests

- **12 vitest schema cases** (valid base58, reject negatives, reject floats, reject missing/extra fields, schema-as-types runtime check)
- **Manual stdio smoke** — `initialize` + `tools/list` + `tools/call status` over stdio all return correct responses

`status` response from the smoke test:
```json
{
  "cluster": "devnet",
  "spendingPub": "188326809...249929263",
  "viewingPub": "6cbc5f12...652cdec2a",
  "walletPubkey": "4ym542u1...fy82t",
  "balances": []
}
```

Pubkey explanation in the PR review thread on [#27](https://github.com/mmchougule/b402-solana/pull/27) — both `spendingPub` and `viewingPub` are public-by-design (Poseidon-derived spending pub + Curve25519 viewing pub respectively).

## Diff

| File | Purpose |
|---|---|
| `packages/mcp-server/src/index.ts` | MCP server entrypoint (stdio transport) |
| `packages/mcp-server/src/context.ts` | env-driven `B402Solana` instantiation |
| `packages/mcp-server/src/schemas.ts` | zod input schemas |
| `packages/mcp-server/src/tools/{shield,unshield,private_swap,status}.ts` | tool handlers (5–25 LoC each) |
| `packages/mcp-server/src/__tests__/schemas.test.ts` | 12 vitest cases |
| `packages/mcp-server/{package.json,tsconfig.json,tsconfig.build.json,README.md}` | package config + docs |
| `pnpm-workspace.yaml` | adds `packages/mcp-server` |
| `pnpm-lock.yaml` | adds `@modelcontextprotocol/sdk`, `zod`, `zod-to-json-schema` |

~310 LoC of source; 14 files changed.

## Out of scope

- npm publish — package is workspace-private at v0.0.1; no publish step in CI
- HTTP/SSE transport — stdio only for v0
- `private_lend` and `redeem` — wait for v2 ABI / PR #16
- Auto-funding — caller is responsible for SOL on the wallet

## Test plan

- [x] `pnpm --filter '@b402ai/solana-mcp' build` exits 0
- [x] `pnpm --filter '@b402ai/solana-mcp' test` 12/12 pass
- [x] Manual stdio smoke (initialize + tools/list + status call)
- [ ] CI green
- [ ] Reviewer wires `claude mcp add` locally and prompt-drives a `status` call