### PR TITLE
sdk + mcp: quote_swap via Jupiter Lite API

### DIFF
--- a/packages/mcp-server/src/__tests__/schemas.test.ts
+++ b/packages/mcp-server/src/__tests__/schemas.test.ts
@@ -6,6 +6,7 @@ import {
   statusInput,
   holdingsInput,
   balanceInput,
+  quoteSwapInput,
 } from '../schemas.js';
 
 const VALID_PK = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'; // mainnet USDC
@@ -110,6 +111,40 @@ describe('balance input', () => {
   });
 });
 
+describe('quote_swap input', () => {
+  it('accepts valid', () => {
+    expect(() =>
+      quoteSwapInput.parse({ inMint: VALID_PK, outMint: VALID_PK, amount: '1000000' }),
+    ).not.toThrow();
+  });
+  it('accepts slippageBps override', () => {
+    expect(() =>
+      quoteSwapInput.parse({
+        inMint: VALID_PK, outMint: VALID_PK, amount: '1000000', slippageBps: 100,
+      }),
+    ).not.toThrow();
+  });
+  it('rejects slippageBps > 10000', () => {
+    expect(() =>
+      quoteSwapInput.parse({
+        inMint: VALID_PK, outMint: VALID_PK, amount: '1', slippageBps: 99999,
+      }),
+    ).toThrow();
+  });
+  it('rejects negative slippageBps', () => {
+    expect(() =>
+      quoteSwapInput.parse({
+        inMint: VALID_PK, outMint: VALID_PK, amount: '1', slippageBps: -1,
+      }),
+    ).toThrow();
+  });
+  it('rejects float amount', () => {
+    expect(() =>
+      quoteSwapInput.parse({ inMint: VALID_PK, outMint: VALID_PK, amount: '1.5' }),
+    ).toThrow();
+  });
+});
+
 describe('responses contain no secret fields (static guarantee)', () => {
   // Compile-time guard: every tool handler's return type is asserted to be
   // a flat JSON-friendly object with only public fields. The schemas-as-types
@@ -122,5 +157,6 @@ describe('responses contain no secret fields (static guarantee)', () => {
     expect(statusInput._def.typeName).toBe('ZodObject');
     expect(holdingsInput._def.typeName).toBe('ZodObject');
     expect(balanceInput._def.typeName).toBe('ZodObject');
+    expect(quoteSwapInput._def.typeName).toBe('ZodObject');
   });
 });

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -19,6 +19,7 @@
  *   - status        — wallet pubkey + private balances by mint
  *   - holdings      — per-deposit private holdings (id, mint, amount)
  *   - balance       — aggregate private balance per mint
+ *   - quote_swap    — Jupiter quote: expected OUT, slippage, price impact
  *
  * Security:
  *   - Keypair loaded once from disk (B402_KEYPAIR_PATH) and held in memory.
@@ -43,6 +44,7 @@ import {
   statusInput,
   holdingsInput,
   balanceInput,
+  quoteSwapInput,
 } from './schemas.js';
 import { handleShield } from './tools/shield.js';
 import { handleUnshield } from './tools/unshield.js';
@@ -50,6 +52,7 @@ import { handlePrivateSwap } from './tools/private_swap.js';
 import { handleStatus } from './tools/status.js';
 import { handleHoldings } from './tools/holdings.js';
 import { handleBalance } from './tools/balance.js';
+import { handleQuoteSwap } from './tools/quote_swap.js';
 
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
@@ -110,6 +113,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         'Aggregate private balance grouped by mint. The default read tool — pass {mint} to filter and resolve its base58 address. By default refreshes from on-chain history before returning.',
       inputSchema: zodToJsonSchema(balanceInput),
     },
+    {
+      name: 'quote_swap',
+      description:
+        'Quote a swap via Jupiter (mainnet routes only). Returns expected out amount, slippage, price impact and route hop count. Use this before private_swap to predict the outcome — off-chain estimate, actual execution may differ by up to slippageBps.',
+      inputSchema: zodToJsonSchema(quoteSwapInput),
+    },
   ],
 }));
 
@@ -138,6 +147,9 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         break;
       case 'balance':
         result = await handleBalance(ctx(), balanceInput.parse(args));
+        break;
+      case 'quote_swap':
+        result = await handleQuoteSwap(ctx(), quoteSwapInput.parse(args));
         break;
       default:
         throw new Error(`unknown tool: ${name}`);

--- a/packages/mcp-server/src/schemas.ts
+++ b/packages/mcp-server/src/schemas.ts
@@ -68,9 +68,19 @@ export const balanceInput = z
   })
   .strict();
 
+export const quoteSwapInput = z
+  .object({
+    inMint: Base58Pubkey.describe('SPL mint of the IN token'),
+    outMint: Base58Pubkey.describe('SPL mint of the OUT token'),
+    amount: U64String.describe('Amount of inMint to swap, in smallest units'),
+    slippageBps: z.number().int().nonnegative().max(10000).optional().describe('Acceptable slippage in basis points. Default 50 (0.5%).'),
+  })
+  .strict();
+
 export type ShieldInput = z.infer<typeof shieldInput>;
 export type UnshieldInput = z.infer<typeof unshieldInput>;
 export type PrivateSwapInput = z.infer<typeof privateSwapInput>;
 export type StatusInput = z.infer<typeof statusInput>;
 export type HoldingsInput = z.infer<typeof holdingsInput>;
 export type BalanceInput = z.infer<typeof balanceInput>;
+export type QuoteSwapInput = z.infer<typeof quoteSwapInput>;

--- a/packages/mcp-server/src/tools/quote_swap.ts
+++ b/packages/mcp-server/src/tools/quote_swap.ts
@@ -1,0 +1,27 @@
+import { PublicKey } from '@solana/web3.js';
+import type { B402Context } from '../context.js';
+import type { QuoteSwapInput } from '../schemas.js';
+
+export async function handleQuoteSwap(
+  ctx: B402Context,
+  input: QuoteSwapInput,
+): Promise<{
+  cluster: string;
+  inMint: string;
+  outMint: string;
+  inAmount: string;
+  outAmount: string;
+  otherAmountThreshold: string;
+  slippageBps: number;
+  priceImpactPct: string;
+  routeHops: number;
+  contextSlot?: number;
+}> {
+  const q = await ctx.b402.quoteSwap({
+    inMint: new PublicKey(input.inMint),
+    outMint: new PublicKey(input.outMint),
+    amount: BigInt(input.amount),
+    slippageBps: input.slippageBps,
+  });
+  return { cluster: ctx.cluster, ...q };
+}

--- a/packages/sdk/src/b402.ts
+++ b/packages/sdk/src/b402.ts
@@ -691,6 +691,69 @@ export class B402Solana {
   }
 
   /**
+   * Quote a swap via Jupiter Lite API (`https://lite-api.jup.ag/swap/v1`).
+   * Public, no auth. Useful for an agent to predict the OUT amount + slippage
+   * before committing to a `privateSwap` call.
+   *
+   * The quote is an off-chain estimate; actual on-chain execution may differ
+   * by up to `slippageBps`. Mainnet routes only — Jupiter does not index
+   * devnet liquidity.
+   */
+  async quoteSwap(opts: {
+    inMint: PublicKey;
+    outMint: PublicKey;
+    amount: bigint;
+    slippageBps?: number;
+  }): Promise<{
+    inMint: string;
+    outMint: string;
+    inAmount: string;
+    outAmount: string;
+    otherAmountThreshold: string;
+    slippageBps: number;
+    priceImpactPct: string;
+    routeHops: number;
+    contextSlot?: number;
+  }> {
+    const slippageBps = opts.slippageBps ?? 50;
+    const url = new URL('https://lite-api.jup.ag/swap/v1/quote');
+    url.searchParams.set('inputMint', opts.inMint.toBase58());
+    url.searchParams.set('outputMint', opts.outMint.toBase58());
+    url.searchParams.set('amount', opts.amount.toString());
+    url.searchParams.set('slippageBps', String(slippageBps));
+
+    const resp = await fetch(url, { headers: { accept: 'application/json' } });
+    if (!resp.ok) {
+      throw new B402Error(
+        B402ErrorCode.InvalidConfig,
+        `Jupiter quote failed: ${resp.status} ${resp.statusText}`,
+      );
+    }
+    const q = (await resp.json()) as {
+      inputMint: string;
+      outputMint: string;
+      inAmount: string;
+      outAmount: string;
+      otherAmountThreshold: string;
+      slippageBps: number;
+      priceImpactPct: string;
+      routePlan: unknown[];
+      contextSlot?: number;
+    };
+    return {
+      inMint: q.inputMint,
+      outMint: q.outputMint,
+      inAmount: q.inAmount,
+      outAmount: q.outAmount,
+      otherAmountThreshold: q.otherAmountThreshold,
+      slippageBps: q.slippageBps,
+      priceImpactPct: q.priceImpactPct,
+      routeHops: Array.isArray(q.routePlan) ? q.routePlan.length : 0,
+      contextSlot: q.contextSlot,
+    };
+  }
+
+  /**
    * @internal Re-sync from on-chain history. Most agents should use
    * `balance({ refresh: true })` or `holdings({ refresh: true })` instead;
    * this is exposed for advanced cases that want explicit cursor control.


### PR DESCRIPTION
Stacked on #30. Adds Jupiter quote so an agent can predict OUT amount + slippage before committing to private_swap.

## What

- `B402Solana.quoteSwap({ inMint, outMint, amount, slippageBps? })` — calls https://lite-api.jup.ag/swap/v1/quote (public, no auth).
- 1 new MCP tool: `quote_swap`.

## Test plan

- [x] Schema unit tests (5 cases)
- [x] Live verified end-to-end via stdio: 0.1 SOL → 8.4461 USDC, 1 hop
- [x] Repo-wide typecheck clean
- [x] No secrets in diff (audited)

## Scope notes

- Mainnet routes only — Jupiter doesn't index devnet liquidity.
- Off-chain estimate; on-chain execution may differ by up to slippageBps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)