### PR TITLE
sdk + mcp: watch_incoming for cursor-based polling

### DIFF
--- a/packages/mcp-server/src/__tests__/schemas.test.ts
+++ b/packages/mcp-server/src/__tests__/schemas.test.ts
@@ -7,6 +7,7 @@ import {
   holdingsInput,
   balanceInput,
   quoteSwapInput,
+  watchIncomingInput,
 } from '../schemas.js';
 
 const VALID_PK = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'; // mainnet USDC
@@ -145,6 +146,31 @@ describe('quote_swap input', () => {
   });
 });
 
+describe('watch_incoming input', () => {
+  it('accepts empty (first call)', () => {
+    expect(() => watchIncomingInput.parse({})).not.toThrow();
+  });
+  it('accepts opaque cursor string', () => {
+    expect(() => watchIncomingInput.parse({ cursor: 'eyJ2IjoxLCJsIjoiNDIifQ' })).not.toThrow();
+  });
+  it('accepts mint filter', () => {
+    expect(() => watchIncomingInput.parse({ mint: VALID_PK })).not.toThrow();
+  });
+  it('accepts refresh flag', () => {
+    expect(() => watchIncomingInput.parse({ refresh: false })).not.toThrow();
+  });
+  it('rejects extra fields', () => {
+    expect(() =>
+      watchIncomingInput.parse({ extra: 'evil' } as unknown as never),
+    ).toThrow();
+  });
+  it('rejects non-string cursor', () => {
+    expect(() =>
+      watchIncomingInput.parse({ cursor: 42 } as unknown as never),
+    ).toThrow();
+  });
+});
+
 describe('responses contain no secret fields (static guarantee)', () => {
   // Compile-time guard: every tool handler's return type is asserted to be
   // a flat JSON-friendly object with only public fields. The schemas-as-types
@@ -158,5 +184,6 @@ describe('responses contain no secret fields (static guarantee)', () => {
     expect(holdingsInput._def.typeName).toBe('ZodObject');
     expect(balanceInput._def.typeName).toBe('ZodObject');
     expect(quoteSwapInput._def.typeName).toBe('ZodObject');
+    expect(watchIncomingInput._def.typeName).toBe('ZodObject');
   });
 });

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -20,6 +20,7 @@
  *   - holdings      — per-deposit private holdings (id, mint, amount)
  *   - balance       — aggregate private balance per mint
  *   - quote_swap    — Jupiter quote: expected OUT, slippage, price impact
+ *   - watch_incoming — cursor-based poll for newly-arrived private deposits
  *
  * Security:
  *   - Keypair loaded once from disk (B402_KEYPAIR_PATH) and held in memory.
@@ -45,6 +46,7 @@ import {
   holdingsInput,
   balanceInput,
   quoteSwapInput,
+  watchIncomingInput,
 } from './schemas.js';
 import { handleShield } from './tools/shield.js';
 import { handleUnshield } from './tools/unshield.js';
@@ -53,6 +55,7 @@ import { handleStatus } from './tools/status.js';
 import { handleHoldings } from './tools/holdings.js';
 import { handleBalance } from './tools/balance.js';
 import { handleQuoteSwap } from './tools/quote_swap.js';
+import { handleWatchIncoming } from './tools/watch_incoming.js';
 
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
@@ -119,6 +122,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         'Quote a swap via Jupiter (mainnet routes only). Returns expected out amount, slippage, price impact and route hop count. Use this before private_swap to predict the outcome — off-chain estimate, actual execution may differ by up to slippageBps.',
       inputSchema: zodToJsonSchema(quoteSwapInput),
     },
+    {
+      name: 'watch_incoming',
+      description:
+        'Poll for newly-arrived private deposits since an opaque cursor. Pass the cursor returned by the previous call back unchanged on each iteration. Omit cursor on first call to start from the beginning. Returns the new arrivals plus an updated cursor — agents loop with a 2-3s sleep between calls.',
+      inputSchema: zodToJsonSchema(watchIncomingInput),
+    },
   ],
 }));
 
@@ -150,6 +159,9 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         break;
       case 'quote_swap':
         result = await handleQuoteSwap(ctx(), quoteSwapInput.parse(args));
+        break;
+      case 'watch_incoming':
+        result = await handleWatchIncoming(ctx(), watchIncomingInput.parse(args));
         break;
       default:
         throw new Error(`unknown tool: ${name}`);

--- a/packages/mcp-server/src/schemas.ts
+++ b/packages/mcp-server/src/schemas.ts
@@ -77,6 +77,14 @@ export const quoteSwapInput = z
   })
   .strict();
 
+export const watchIncomingInput = z
+  .object({
+    cursor: z.string().optional().describe('Opaque cursor returned by a previous call. Omit on first call to read from the start.'),
+    mint: Base58Pubkey.optional().describe('Optional mint filter; with a filter, the response resolves the mint to its base58 address.'),
+    refresh: z.boolean().optional().describe('Re-sync from on-chain history before reading. Default true.'),
+  })
+  .strict();
+
 export type ShieldInput = z.infer<typeof shieldInput>;
 export type UnshieldInput = z.infer<typeof unshieldInput>;
 export type PrivateSwapInput = z.infer<typeof privateSwapInput>;
@@ -84,3 +92,4 @@ export type StatusInput = z.infer<typeof statusInput>;
 export type HoldingsInput = z.infer<typeof holdingsInput>;
 export type BalanceInput = z.infer<typeof balanceInput>;
 export type QuoteSwapInput = z.infer<typeof quoteSwapInput>;
+export type WatchIncomingInput = z.infer<typeof watchIncomingInput>;

--- a/packages/mcp-server/src/tools/watch_incoming.ts
+++ b/packages/mcp-server/src/tools/watch_incoming.ts
@@ -1,0 +1,19 @@
+import { PublicKey } from '@solana/web3.js';
+import type { B402Context } from '../context.js';
+import type { WatchIncomingInput } from '../schemas.js';
+
+export async function handleWatchIncoming(
+  ctx: B402Context,
+  input: WatchIncomingInput,
+): Promise<{
+  cluster: string;
+  incoming: Array<{ id: string; mint: string; amount: string; receivedAt: number }>;
+  cursor: string;
+}> {
+  const r = await ctx.b402.watchIncoming({
+    cursor: input.cursor,
+    mint: input.mint ? new PublicKey(input.mint) : undefined,
+    refresh: input.refresh,
+  });
+  return { cluster: ctx.cluster, ...r };
+}

--- a/packages/sdk/src/__tests__/read-side.test.ts
+++ b/packages/sdk/src/__tests__/read-side.test.ts
@@ -77,4 +77,36 @@ describe('NoteStore read-side', () => {
     expect(store.getSpendable(200n)).toHaveLength(1);
     expect(store.getSpendable(999n)).toHaveLength(0);
   });
+
+  it('getSpendableSince returns only notes past the cursor, sorted', () => {
+    const store = buildStore();
+    const mkNote = (leaf: bigint, mint: bigint): SpendableNote => ({
+      ...note(leaf, mint, 1n),
+      leafIndex: leaf,
+    });
+    // @ts-expect-error
+    store.notesByCommitment.set('a', mkNote(5n, 100n));
+    // @ts-expect-error
+    store.notesByCommitment.set('b', mkNote(2n, 100n));
+    // @ts-expect-error
+    store.notesByCommitment.set('c', mkNote(8n, 200n));
+    // @ts-expect-error
+    store.notesByCommitment.set('d', mkNote(3n, 100n));
+
+    expect(store.getSpendableSince(3n).map((n) => n.leafIndex)).toEqual([5n, 8n]);
+    expect(store.getSpendableSince(-1n).map((n) => n.leafIndex)).toEqual([2n, 3n, 5n, 8n]);
+    expect(store.getSpendableSince(3n, 100n).map((n) => n.leafIndex)).toEqual([5n]);
+  });
+
+  it('getSpendableSince excludes spent notes', () => {
+    const store = buildStore();
+    // @ts-expect-error
+    store.notesByCommitment.set('a', { ...note(5n, 100n, 1n), leafIndex: 5n });
+    // @ts-expect-error
+    store.notesByCommitment.set('b', { ...note(7n, 100n, 1n), leafIndex: 7n });
+    // @ts-expect-error
+    store.spentNullifiers.add('5');
+
+    expect(store.getSpendableSince(-1n).map((n) => n.leafIndex)).toEqual([7n]);
+  });
 });

--- a/packages/sdk/src/b402.ts
+++ b/packages/sdk/src/b402.ts
@@ -691,6 +691,46 @@ export class B402Solana {
   }
 
   /**
+   * Poll for newly-arrived private deposits since a cursor. The cursor is
+   * an opaque token returned by previous calls — pass it back unchanged on
+   * each iteration. Omit it (or pass `undefined`) on the first call to read
+   * everything from the start.
+   *
+   * The SDK's live note subscription pushes new arrivals into the in-memory
+   * store as they land on-chain, so polling every few seconds gives an
+   * agent a near-real-time stream of incoming deposits without running a
+   * subscription protocol.
+   *
+   * Output is JSON-friendly with no ZK plumbing exposed.
+   */
+  async watchIncoming(opts: {
+    cursor?: string;
+    mint?: PublicKey;
+    refresh?: boolean;
+  } = {}): Promise<{
+    incoming: Array<{ id: string; mint: string; amount: string; receivedAt: number }>;
+    cursor: string;
+  }> {
+    await this.ready();
+    if (opts.refresh !== false) await this._notes!.backfill({ limit: 100 });
+    const since = decodeCursor(opts.cursor);
+    const filterFr = opts.mint ? leToFrReduced(opts.mint.toBytes()) : undefined;
+    const fresh = this._notes!.getSpendableSince(since, filterFr);
+    let max = since;
+    for (const n of fresh) if (n.leafIndex > max) max = n.leafIndex;
+    const now = Date.now();
+    return {
+      incoming: fresh.map((n) => ({
+        id: noteId(n.commitment),
+        mint: mintLabel(n.tokenMint, opts.mint),
+        amount: n.value.toString(),
+        receivedAt: now,
+      })),
+      cursor: encodeCursor(max),
+    };
+  }
+
+  /**
    * Quote a swap via Jupiter Lite API (`https://lite-api.jup.ag/swap/v1`).
    * Public, no auth. Useful for an agent to predict the OUT amount + slippage
    * before committing to a `privateSwap` call.
@@ -777,6 +817,26 @@ export class B402Solana {
  *  commitment — stable across calls, doesn't reveal anything spendable. */
 function noteId(commitment: bigint): string {
   return commitment.toString(16).padStart(64, '0').slice(0, 16);
+}
+
+/** Encode an internal cursor (currently a leaf index) into an opaque base64url
+ *  token. Versioned so the encoding can change without breaking clients. */
+function encodeCursor(leafIndex: bigint): string {
+  const payload = JSON.stringify({ v: 1, l: leafIndex.toString() });
+  return Buffer.from(payload, 'utf8').toString('base64url');
+}
+
+/** Decode an opaque cursor token back into an internal leaf index. Treats
+ *  missing/malformed cursors as "from the beginning". */
+function decodeCursor(cursor: string | undefined): bigint {
+  if (!cursor) return -1n;
+  try {
+    const obj = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as { v?: number; l?: string };
+    if (obj.v !== 1 || typeof obj.l !== 'string') return -1n;
+    return BigInt(obj.l);
+  } catch {
+    return -1n;
+  }
 }
 
 /** Resolve a Fr-reduced mint value to a human-readable label. If the caller

--- a/packages/sdk/src/note-store.ts
+++ b/packages/sdk/src/note-store.ts
@@ -68,6 +68,23 @@ export class NoteStore {
     return out;
   }
 
+  /**
+   * Notes whose `leafIndex` is strictly greater than `sinceLeafIndex`,
+   * sorted ascending. Powers the cursor-based `watchIncoming` flow — the
+   * leaf index is an internal detail, never surfaced past the SDK boundary.
+   */
+  getSpendableSince(sinceLeafIndex: bigint, tokenMint?: bigint): SpendableNote[] {
+    const out: SpendableNote[] = [];
+    for (const n of this.notesByCommitment.values()) {
+      if (this.spentNullifiers.has(String(n.commitment))) continue;
+      if (n.leafIndex <= sinceLeafIndex) continue;
+      if (tokenMint != null && n.tokenMint !== tokenMint) continue;
+      out.push(n);
+    }
+    out.sort((a, b) => (a.leafIndex < b.leafIndex ? -1 : a.leafIndex > b.leafIndex ? 1 : 0));
+    return out;
+  }
+
   markSpent(nullifier: bigint): void {
     this.spentNullifiers.add(String(nullifier));
   }


### PR DESCRIPTION
Stacked on #31. Cursor-based polling for newly-arrived private deposits — the autonomy unlock for agent loops.

## Public surface

```ts
let cursor: string | undefined;
while (running) {
  const r = await b402.watchIncoming({ cursor });
  cursor = r.cursor;
  for (const d of r.incoming) console.log('new deposit:', d.amount, d.mint, d.id);
  await sleep(2_000);
}
```

- Cursor is **opaque base64url** — clients pass it back unchanged. Internally it encodes a leaf index, but that detail is private to the SDK; the encoding can change without breaking clients (versioned with `v: 1`).
- Output: `{id, mint, amount, receivedAt}` per deposit. No commitment, no leaf index, no Fr-reduced bigints.

## Why polling, not SSE

The SDK's existing live note subscription pushes new deposits into the in-memory store via `connection.onLogs` as they land on-chain. `watch_incoming` exposes that already-live data behind a cursor that's cheap enough to poll every 2-3s — gets us 90% of subscription UX with zero new processes and zero risk.

A real SSE/streaming sidecar can land later when there's a concrete agent that actually needs sub-second latency.

## Test plan

- [x] 9 SDK + 31 MCP unit tests
- [x] Repo-wide typecheck clean
- [x] No secrets in diff (audited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)