### PR TITLE
mcp: private_swap auto-resolves adapter / ALT / scratch ATAs

### DIFF
--- a/packages/mcp-server/src/__tests__/schemas.test.ts
+++ b/packages/mcp-server/src/__tests__/schemas.test.ts
@@ -48,14 +48,10 @@ describe('private_swap input', () => {
         inMint: VALID_PK,
         outMint: VALID_PK,
         amount: '1000000',
-        adapterProgramId: VALID_PK,
-        adapterInTa: VALID_PK,
-        adapterOutTa: VALID_PK,
-        alt: VALID_PK,
       }),
     ).not.toThrow();
   });
-  it('rejects missing alt', () => {
+  it('accepts full override (all four routing fields)', () => {
     expect(() =>
       privateSwapInput.parse({
         inMint: VALID_PK,
@@ -64,6 +60,35 @@ describe('private_swap input', () => {
         adapterProgramId: VALID_PK,
         adapterInTa: VALID_PK,
         adapterOutTa: VALID_PK,
+        alt: VALID_PK,
+      }),
+    ).not.toThrow();
+  });
+  it('accepts slippageBps override', () => {
+    expect(() =>
+      privateSwapInput.parse({
+        inMint: VALID_PK, outMint: VALID_PK, amount: '1000000', slippageBps: 100,
+      }),
+    ).not.toThrow();
+  });
+  it('accepts expectedOut override', () => {
+    expect(() =>
+      privateSwapInput.parse({
+        inMint: VALID_PK, outMint: VALID_PK, amount: '1000000', expectedOut: '8400000',
+      }),
+    ).not.toThrow();
+  });
+  it('rejects float amount', () => {
+    expect(() =>
+      privateSwapInput.parse({
+        inMint: VALID_PK, outMint: VALID_PK, amount: '1.5',
+      }),
+    ).toThrow();
+  });
+  it('rejects extra fields', () => {
+    expect(() =>
+      privateSwapInput.parse({
+        inMint: VALID_PK, outMint: VALID_PK, amount: '1', evil: true,
       } as unknown as never),
     ).toThrow();
   });

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -95,7 +95,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'private_swap',
       description:
-        'Atomic private swap: spend a private deposit in the IN token, route through a registered adapter, deposit the OUT token back into a fresh private balance. Requires a pre-existing private deposit in the IN mint. Returns the swap signature and output amount.',
+        'Atomic private swap: spend a private deposit in the IN token, route through a registered adapter, deposit the OUT token back into a fresh private balance. Pass {inMint, outMint, amount} — the adapter program, ALT, scratch ATAs and expected-out are auto-resolved from the configured cluster (Jupiter + quote-derived expectedOut on mainnet; mock adapter on devnet). Requires a pre-existing private deposit in the IN mint. Returns the swap signature, output amount and a new opaque deposit id.',
       inputSchema: zodToJsonSchema(privateSwapInput),
     },
     {

--- a/packages/mcp-server/src/schemas.ts
+++ b/packages/mcp-server/src/schemas.ts
@@ -42,13 +42,15 @@ export const unshieldInput = z
 
 export const privateSwapInput = z
   .object({
-    inMint: Base58Pubkey.describe('Mint of the IN token (a shielded note in this mint must already exist for the caller)'),
+    inMint: Base58Pubkey.describe('Mint of the IN token (a private deposit in this mint must already exist for the caller)'),
     outMint: Base58Pubkey.describe('Mint of the OUT token'),
     amount: U64String.describe('Amount of inMint to swap, in smallest units'),
-    adapterProgramId: Base58Pubkey.describe('Program ID of the adapter handling the swap'),
-    adapterInTa: Base58Pubkey.describe('Adapter-side scratch ATA for IN mint'),
-    adapterOutTa: Base58Pubkey.describe('Adapter-side scratch ATA for OUT mint'),
-    alt: Base58Pubkey.describe('Address Lookup Table that compresses the v0 tx account list'),
+    slippageBps: z.number().int().nonnegative().max(10000).optional().describe('Acceptable slippage in basis points. Default 50 (0.5%). Used on mainnet to derive expectedOut from a Jupiter quote.'),
+    adapterProgramId: Base58Pubkey.optional().describe('Override adapter program. Defaults to Jupiter (mainnet) or mock (devnet).'),
+    adapterInTa: Base58Pubkey.optional().describe('Override adapter IN scratch ATA. Auto-derived from the adapter PDA + IN mint when omitted.'),
+    adapterOutTa: Base58Pubkey.optional().describe('Override adapter OUT scratch ATA. Auto-derived from the adapter PDA + OUT mint when omitted.'),
+    alt: Base58Pubkey.optional().describe('Override Address Lookup Table. Defaults to the canonical b402 ALT for the configured cluster.'),
+    expectedOut: U64String.optional().describe('Override expected OUT amount (smallest units). On mainnet auto-resolved from a Jupiter quote with slippageBps applied.'),
   })
   .strict();
 

--- a/packages/mcp-server/src/tools/private_swap.ts
+++ b/packages/mcp-server/src/tools/private_swap.ts
@@ -1,31 +1,90 @@
 import { PublicKey } from '@solana/web3.js';
+import { getAssociatedTokenAddress } from '@solana/spl-token';
+import { PROGRAM_IDS, B402_ALT_DEVNET, B402_ALT_MAINNET } from '@b402ai/solana-shared';
 import type { B402Context } from '../context.js';
 import type { PrivateSwapInput } from '../schemas.js';
 
+/**
+ * Auto-resolves adapter / ALT / scratch ATAs / expectedOut from the configured
+ * cluster so an agent only has to pass {inMint, outMint, amount}.
+ *
+ * - mainnet → Jupiter adapter, mainnet ALT, expectedOut from a Jupiter quote
+ *   (slippageBps applied)
+ * - devnet → mock adapter, devnet ALT, expectedOut defaults to amount * 2n
+ *   (the SDK default — the deployed devnet mock adapter is constant-rate)
+ *
+ * Adapter scratch ATAs are derived from the adapter program's
+ * `[b402/v1, adapter]` PDA + the corresponding mint, matching the convention
+ * used by the deployed adapters on devnet (see examples/sdk-quick-swap.ts).
+ */
 export async function handlePrivateSwap(
   ctx: B402Context,
   input: PrivateSwapInput,
 ): Promise<{
   signature: string;
   outAmount: string;
-  outCommitment: string;
-  outLeafIndex: string;
+  outDepositId: string;
   cluster: string;
 }> {
+  const cluster = ctx.cluster;
+  const inMint = new PublicKey(input.inMint);
+  const outMint = new PublicKey(input.outMint);
+  const amount = BigInt(input.amount);
+
+  const adapterProgramId = input.adapterProgramId
+    ? new PublicKey(input.adapterProgramId)
+    : new PublicKey(
+        cluster === 'mainnet' ? PROGRAM_IDS.b402JupiterAdapter : PROGRAM_IDS.b402MockAdapter,
+      );
+
+  const adapterAuthority = PublicKey.findProgramAddressSync(
+    [new TextEncoder().encode('b402/v1'), new TextEncoder().encode('adapter')],
+    adapterProgramId,
+  )[0];
+
+  const adapterInTa = input.adapterInTa
+    ? new PublicKey(input.adapterInTa)
+    : await getAssociatedTokenAddress(inMint, adapterAuthority, true);
+
+  const adapterOutTa = input.adapterOutTa
+    ? new PublicKey(input.adapterOutTa)
+    : await getAssociatedTokenAddress(outMint, adapterAuthority, true);
+
+  const altStr =
+    input.alt ?? (cluster === 'mainnet' ? B402_ALT_MAINNET : B402_ALT_DEVNET);
+  if (!altStr) {
+    throw new Error(
+      `no Address Lookup Table configured for ${cluster}. Set B402_ALT_${cluster.toUpperCase()} in the SDK constants or pass alt explicitly.`,
+    );
+  }
+  const alt = new PublicKey(altStr);
+
+  let expectedOut: bigint | undefined;
+  if (input.expectedOut) {
+    expectedOut = BigInt(input.expectedOut);
+  } else if (cluster === 'mainnet') {
+    const slippageBps = input.slippageBps ?? 50;
+    const q = await ctx.b402.quoteSwap({ inMint, outMint, amount, slippageBps });
+    expectedOut = BigInt(q.otherAmountThreshold);
+  }
+  // On devnet without an explicit expectedOut, fall through — SDK defaults to
+  // amount * 2n which matches the mock adapter's behaviour.
+
   const result = await ctx.b402.privateSwap({
-    inMint: new PublicKey(input.inMint),
-    outMint: new PublicKey(input.outMint),
-    amount: BigInt(input.amount),
-    adapterProgramId: new PublicKey(input.adapterProgramId),
-    adapterInTa: new PublicKey(input.adapterInTa),
-    adapterOutTa: new PublicKey(input.adapterOutTa),
-    alt: new PublicKey(input.alt),
+    inMint,
+    outMint,
+    amount,
+    adapterProgramId,
+    adapterInTa,
+    adapterOutTa,
+    alt,
+    ...(expectedOut !== undefined ? { expectedOut } : {}),
   });
+
   return {
     signature: result.signature,
     outAmount: result.outAmount.toString(),
-    outCommitment: result.outNote.commitment.toString(),
-    outLeafIndex: result.outNote.leafIndex.toString(),
-    cluster: ctx.cluster,
+    outDepositId: result.outNote.commitment.toString(16).padStart(64, '0').slice(0, 16),
+    cluster,
   };
 }


### PR DESCRIPTION
Stacked on #32. Makes the MCP \`private_swap\` tool callable with just \`{inMint, outMint, amount}\` — adapter program, Address Lookup Table, and adapter-side scratch ATAs are auto-resolved from the configured cluster.

## Why

An agent shouldn't need to know what adapter PDA derivation looks like, what an ALT is, or what scratch ATAs to pre-fund. The previous MCP shape required all four — fine for tests, hostile for Claude Code / Cursor prompts.

## Resolution rules

- \`adapterProgramId\` → Jupiter (mainnet) | Mock (devnet) [from PROGRAM_IDS]
- \`alt\` → \`B402_ALT_MAINNET\` | \`B402_ALT_DEVNET\`
- \`adapterInTa\` / \`adapterOutTa\` → \`ATA(adapter PDA, mint)\` derived from the adapter program's \`[b402/v1, adapter]\` PDA
- \`expectedOut\` →
  - mainnet: from a Jupiter quote with \`slippageBps\` applied (\`otherAmountThreshold\`)
  - devnet: SDK default (\`amount * 2\`) matches the deployed mock adapter's constant-rate behaviour

All four routing fields remain available as overrides for callers that need custom adapters / ALTs / pre-funded scratch accounts.

## Test plan

- [x] 35 MCP unit tests (added 4 new cases for the relaxed shape: minimal valid call, full override, slippageBps, expectedOut)
- [x] Live verified via stdio that schema reports \`required: [inMint, outMint, amount]\`
- [x] Repo-wide typecheck clean
- [x] No secrets in diff (audited)

## Why honest about devnet

The mock adapter on devnet is **constant 2x echo**, not a real swap. The SDK defaults to it on devnet because Jupiter has no devnet liquidity. On mainnet the SAME code path routes through the deployed Jupiter adapter to real AMMs.

Tool description names this explicitly so an agent's user understands what they're seeing on each cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)