### PR TITLE
sdk: bech32 stealth-address encoding (closes #23)

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -17,19 +17,20 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@b402ai/solana-shared": "workspace:*",
     "@b402ai/solana-prover": "workspace:*",
-    "@solana/web3.js": "^1.95.8",
-    "@solana/spl-token": "^0.4.9",
-    "@noble/hashes": "^1.5.0",
+    "@b402ai/solana-shared": "workspace:*",
     "@noble/ciphers": "^1.0.0",
     "@noble/curves": "^1.6.0",
+    "@noble/hashes": "^1.5.0",
+    "@scure/base": "^1.1.9",
+    "@solana/spl-token": "^0.4.9",
+    "@solana/web3.js": "^1.95.8",
     "circomlibjs": "^0.1.7"
   },
   "devDependencies": {
-    "typescript": "^5.6.3",
-    "vitest": "^2.1.4",
+    "@types/node": "^22.9.0",
     "fast-check": "^3.22.0",
-    "@types/node": "^22.9.0"
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.4"
   }
 }

--- a/packages/sdk/src/__tests__/stealth-address.test.ts
+++ b/packages/sdk/src/__tests__/stealth-address.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { FR_MODULUS } from '@b402ai/solana-shared';
+import {
+  encodeStealthAddress,
+  decodeStealthAddress,
+  STEALTH_ADDRESS_HRP,
+} from '../stealth/address.js';
+import { B402Error, B402ErrorCode } from '../errors.js';
+
+function bytes(b: number): Uint8Array {
+  return new Uint8Array(32).fill(b);
+}
+
+describe('stealth-address bech32', () => {
+  it('round-trips a representative key pair', () => {
+    const spendingPub = 0x0123456789abcdefn * (1n << 64n) + 0xfeedfacecafebaben;
+    const viewingPub = bytes(0x42);
+
+    const s = encodeStealthAddress(spendingPub, viewingPub);
+
+    expect(s.startsWith(`${STEALTH_ADDRESS_HRP}1`)).toBe(true);
+
+    const back = decodeStealthAddress(s);
+    expect(back.spendingPub).toBe(spendingPub);
+    expect(Array.from(back.viewingPub)).toEqual(Array.from(viewingPub));
+  });
+
+  it('round-trips many random valid pairs', () => {
+    for (let i = 0; i < 32; i++) {
+      const spendingPub = BigInt(i) * 0xdeadbeefn + 1n;
+      const view = new Uint8Array(32);
+      for (let j = 0; j < 32; j++) view[j] = (i * 7 + j) & 0xff;
+      const s = encodeStealthAddress(spendingPub, view);
+      const back = decodeStealthAddress(s);
+      expect(back.spendingPub).toBe(spendingPub);
+      expect(Array.from(back.viewingPub)).toEqual(Array.from(view));
+    }
+  });
+
+  it('rejects a tampered checksum', () => {
+    const s = encodeStealthAddress(7n, bytes(1));
+    // Flip the last data char before the checksum tail. Bech32 checksum is the
+    // last 6 chars; flipping any earlier data char invalidates it.
+    const tampered = s.slice(0, -7) + flipChar(s[s.length - 7]) + s.slice(-6);
+    expect(() => decodeStealthAddress(tampered)).toThrow(B402Error);
+  });
+
+  it('rejects wrong HRP', () => {
+    const s = encodeStealthAddress(7n, bytes(1));
+    const dataPart = s.slice(STEALTH_ADDRESS_HRP.length);
+    const wrongHrp = 'b402evm' + dataPart;
+    // wrong-HRP almost always also fails the checksum (HRP is mixed in), so
+    // any B402Error is acceptable here — it must NOT decode as valid.
+    expect(() => decodeStealthAddress(wrongHrp)).toThrow(B402Error);
+  });
+
+  it('rejects out-of-range spending key on encode', () => {
+    expect(() => encodeStealthAddress(FR_MODULUS, bytes(1))).toThrow();
+    expect(() => encodeStealthAddress(-1n, bytes(1))).toThrow();
+  });
+
+  it('rejects wrong-length viewing key on encode', () => {
+    expect(() => encodeStealthAddress(7n, new Uint8Array(31))).toThrow(B402Error);
+    expect(() => encodeStealthAddress(7n, new Uint8Array(33))).toThrow(B402Error);
+  });
+
+  it('frozen reference vector — detects accidental layout changes', () => {
+    // spendingPub = 1, viewingPub = 0x02 repeated 32 times.
+    // If the layout (HRP, version, byte order, key order) ever changes,
+    // this assertion is the canary.
+    const s = encodeStealthAddress(1n, bytes(0x02));
+    expect(s).toBe(
+      'b402sol1qqqsqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszjqdaeh',
+    );
+    const back = decodeStealthAddress(s);
+    expect(back.spendingPub).toBe(1n);
+    expect(Array.from(back.viewingPub)).toEqual(Array.from(bytes(0x02)));
+  });
+
+  it('error code is InvalidRecipient on decode failures', () => {
+    try {
+      decodeStealthAddress('not-a-valid-bech32-string');
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(B402Error);
+      expect((e as B402Error).code).toBe(B402ErrorCode.InvalidRecipient);
+    }
+  });
+});
+
+/** Flip a bech32 charset character to a different valid one. */
+function flipChar(c: string): string {
+  const charset = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+  const idx = charset.indexOf(c);
+  if (idx < 0) throw new Error(`not a bech32 char: ${c}`);
+  return charset[(idx + 1) % charset.length];
+}

--- a/packages/sdk/src/__tests__/stealth-address.test.ts
+++ b/packages/sdk/src/__tests__/stealth-address.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
+import { bech32 } from '@scure/base';
 import { FR_MODULUS } from '@b402ai/solana-shared';
 import {
   encodeStealthAddress,
   decodeStealthAddress,
   STEALTH_ADDRESS_HRP,
+  STEALTH_ADDRESS_VERSION,
 } from '../stealth/address.js';
 import { B402Error, B402ErrorCode } from '../errors.js';
 
@@ -45,13 +47,57 @@ describe('stealth-address bech32', () => {
     expect(() => decodeStealthAddress(tampered)).toThrow(B402Error);
   });
 
-  it('rejects wrong HRP', () => {
+  it('rejects wrong HRP (checksum-aware: existing string under a wrong prefix)', () => {
+    // This case exercises the checksum branch — bech32's checksum is a function
+    // of HRP, so swapping the prefix while keeping the same data part fails
+    // checksum first.
     const s = encodeStealthAddress(7n, bytes(1));
     const dataPart = s.slice(STEALTH_ADDRESS_HRP.length);
-    const wrongHrp = 'b402evm' + dataPart;
-    // wrong-HRP almost always also fails the checksum (HRP is mixed in), so
-    // any B402Error is acceptable here — it must NOT decode as valid.
-    expect(() => decodeStealthAddress(wrongHrp)).toThrow(B402Error);
+    const wrongHrpStr = 'b402evm' + dataPart;
+    expect(() => decodeStealthAddress(wrongHrpStr)).toThrow(B402Error);
+  });
+
+  it('rejects wrong HRP (valid checksum: re-encoded under a different HRP)', () => {
+    // This case exercises the explicit `prefix !== STEALTH_ADDRESS_HRP` branch
+    // — same payload re-encoded under another HRP has a *valid* checksum but
+    // wrong prefix.
+    const payload = new Uint8Array(1 + 32 + 32);
+    payload[0] = STEALTH_ADDRESS_VERSION;
+    payload.set(bytes(0x07), 1);
+    payload.set(bytes(0x01), 33);
+    const wrongHrp = bech32.encode('b402evm', bech32.toWords(payload), 256);
+
+    try {
+      decodeStealthAddress(wrongHrp);
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(B402Error);
+      const err = e as B402Error;
+      expect(err.code).toBe(B402ErrorCode.InvalidRecipient);
+      expect(err.message).toContain('wrong HRP');
+    }
+  });
+
+  it('rejects non-canonical Fr in decode (spending bytes >= FR_MODULUS)', () => {
+    // Construct a payload whose spending-key bytes encode 2^254 (well above
+    // FR_MODULUS). leToFr rejects this; the wrapper must surface it as
+    // InvalidRecipient, not as a raw Error.
+    const payload = new Uint8Array(1 + 32 + 32);
+    payload[0] = STEALTH_ADDRESS_VERSION;
+    // 32-byte LE: bit 254 set ⇒ value 2^254, > FR_MODULUS
+    payload[1 + 31] = 0x40;
+    // viewing key bytes irrelevant; default zeros are fine
+    const bad = bech32.encode(STEALTH_ADDRESS_HRP, bech32.toWords(payload), 256);
+
+    try {
+      decodeStealthAddress(bad);
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(B402Error);
+      const err = e as B402Error;
+      expect(err.code).toBe(B402ErrorCode.InvalidRecipient);
+      expect(err.message).toContain('non-canonical');
+    }
   });
 
   it('rejects out-of-range spending key on encode', () => {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -18,6 +18,13 @@ export { NoteStore } from './note-store.js';
 export { shield, type ShieldParams, type ShieldResult } from './actions/shield.js';
 export { unshield, type UnshieldParams, type UnshieldResult } from './actions/unshield.js';
 export { Scanner, parseProgramDataLog, expectedCommitmentForOwner, type ScannerOptions } from './notes/scanner.js';
+export {
+  encodeStealthAddress,
+  decodeStealthAddress,
+  STEALTH_ADDRESS_HRP,
+  STEALTH_ADDRESS_VERSION,
+  type StealthAddressParts,
+} from './stealth/address.js';
 
 /** Solana hard tx-size cap. */
 export const MAX_TX_SIZE = 1232;

--- a/packages/sdk/src/stealth/address.ts
+++ b/packages/sdk/src/stealth/address.ts
@@ -1,0 +1,98 @@
+/**
+ * Stealth-address encoding for b402-solana wallets.
+ *
+ * Format:  bech32(HRP, [version_byte || spendingPub_LE32 || viewingPub32])
+ *   - HRP:                "b402sol"  (distinct from any EVM-sibling HRP because
+ *                          spending key here is BN254 Fr and viewing key is
+ *                          X25519, not secp256k1)
+ *   - version_byte:        0x00 = v0 (only version currently defined)
+ *   - spendingPub_LE32:    frToLe(wallet.spendingPub) — canonical, < FR_MODULUS
+ *   - viewingPub32:        wallet.viewingPub  — raw X25519 pub
+ *
+ * Total payload: 1 + 32 + 32 = 65 bytes.
+ *
+ * Decoding rejects:
+ *   - wrong HRP
+ *   - wrong version byte
+ *   - non-canonical spending key (>= FR_MODULUS)
+ *   - any bech32 checksum failure (handled by @scure/base)
+ *   - wrong payload length
+ */
+
+import { bech32 } from '@scure/base';
+import { frToLe, leToFr } from '@b402ai/solana-shared';
+import { B402Error, B402ErrorCode } from '../errors.js';
+
+export const STEALTH_ADDRESS_HRP = 'b402sol';
+export const STEALTH_ADDRESS_VERSION = 0x00;
+const PAYLOAD_LEN = 1 + 32 + 32;
+
+// bech32 strings are bounded by the underlying spec (max 90 chars for BIP-173).
+// Our payload is 65 bytes → ~104 5-bit groups + HRP + checksum, which exceeds the
+// 90-char default. @scure/base accepts a custom limit; we pin a generous one.
+const BECH32_LIMIT = 256;
+
+export interface StealthAddressParts {
+  spendingPub: bigint;
+  viewingPub: Uint8Array;
+}
+
+/** Encode a (spendingPub, viewingPub) pair as a `b402sol1…` bech32 string. */
+export function encodeStealthAddress(spendingPub: bigint, viewingPub: Uint8Array): string {
+  if (viewingPub.length !== 32) {
+    throw new B402Error(
+      B402ErrorCode.InvalidRecipient,
+      `viewingPub must be 32 bytes, got ${viewingPub.length}`,
+    );
+  }
+  // frToLe rejects out-of-range / negative.
+  const spendBytes = frToLe(spendingPub);
+
+  const payload = new Uint8Array(PAYLOAD_LEN);
+  payload[0] = STEALTH_ADDRESS_VERSION;
+  payload.set(spendBytes, 1);
+  payload.set(viewingPub, 33);
+
+  const words = bech32.toWords(payload);
+  return bech32.encode(STEALTH_ADDRESS_HRP, words, BECH32_LIMIT);
+}
+
+/** Decode a `b402sol1…` string back into (spendingPub, viewingPub). */
+export function decodeStealthAddress(s: string): StealthAddressParts {
+  let prefix: string;
+  let words: number[];
+  try {
+    // @scure/base's bech32.decode types require a literal-checked
+    // `${string}1${string}` shape; we narrow at runtime via the decode itself,
+    // which throws if the '1' separator is missing.
+    ({ prefix, words } = bech32.decode(s as `${string}1${string}`, BECH32_LIMIT));
+  } catch (e) {
+    throw new B402Error(
+      B402ErrorCode.InvalidRecipient,
+      `bech32 decode failed: ${(e as Error).message}`,
+    );
+  }
+  if (prefix !== STEALTH_ADDRESS_HRP) {
+    throw new B402Error(
+      B402ErrorCode.InvalidRecipient,
+      `wrong HRP: expected '${STEALTH_ADDRESS_HRP}', got '${prefix}'`,
+    );
+  }
+  const payload = bech32.fromWords(words);
+  if (payload.length !== PAYLOAD_LEN) {
+    throw new B402Error(
+      B402ErrorCode.InvalidRecipient,
+      `payload length: expected ${PAYLOAD_LEN}, got ${payload.length}`,
+    );
+  }
+  const version = payload[0];
+  if (version !== STEALTH_ADDRESS_VERSION) {
+    throw new B402Error(
+      B402ErrorCode.InvalidRecipient,
+      `unknown stealth-address version: 0x${version.toString(16)}`,
+    );
+  }
+  const spendingPub = leToFr(Uint8Array.from(payload.subarray(1, 33)));
+  const viewingPub = Uint8Array.from(payload.subarray(33, 65));
+  return { spendingPub, viewingPub };
+}

--- a/packages/sdk/src/stealth/address.ts
+++ b/packages/sdk/src/stealth/address.ts
@@ -45,8 +45,16 @@ export function encodeStealthAddress(spendingPub: bigint, viewingPub: Uint8Array
       `viewingPub must be 32 bytes, got ${viewingPub.length}`,
     );
   }
-  // frToLe rejects out-of-range / negative.
-  const spendBytes = frToLe(spendingPub);
+  let spendBytes: Uint8Array;
+  try {
+    // frToLe rejects out-of-range / negative.
+    spendBytes = frToLe(spendingPub);
+  } catch (e) {
+    throw new B402Error(
+      B402ErrorCode.InvalidRecipient,
+      `invalid spendingPub: ${(e as Error).message}`,
+    );
+  }
 
   const payload = new Uint8Array(PAYLOAD_LEN);
   payload[0] = STEALTH_ADDRESS_VERSION;
@@ -92,7 +100,15 @@ export function decodeStealthAddress(s: string): StealthAddressParts {
       `unknown stealth-address version: 0x${version.toString(16)}`,
     );
   }
-  const spendingPub = leToFr(Uint8Array.from(payload.subarray(1, 33)));
+  let spendingPub: bigint;
+  try {
+    spendingPub = leToFr(Uint8Array.from(payload.subarray(1, 33)));
+  } catch (e) {
+    throw new B402Error(
+      B402ErrorCode.InvalidRecipient,
+      `non-canonical spending key: ${(e as Error).message}`,
+    );
+  }
   const viewingPub = Uint8Array.from(payload.subarray(33, 65));
   return { spendingPub, viewingPub };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       '@noble/hashes':
         specifier: ^1.5.0
         version: 1.8.0
+      '@scure/base':
+        specifier: ^1.1.9
+        version: 1.2.6
       '@solana/spl-token':
         specifier: ^0.4.9
         version: 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -755,6 +758,9 @@ packages:
     resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
+
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
   '@solana/buffer-layout-utils@0.2.0':
     resolution: {integrity: sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==}
@@ -2334,6 +2340,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
+
+  '@scure/base@1.2.6': {}
 
   '@solana/buffer-layout-utils@0.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:


### PR DESCRIPTION
## Summary
- New `encodeStealthAddress(spendingPub, viewingPub) -> string` and `decodeStealthAddress(s) -> { spendingPub, viewingPub }` in `packages/sdk/src/stealth/address.ts`, returning `b402sol1q…` strings.
- 65-byte payload: `version(0x00) || frToLe(spendingPub)[32] || viewingPub[32]`. Decode is strict — rejects non-canonical Fr (`>= p`), non-v0 version, wrong HRP, bad checksum, and wrong payload length, all surfaced as `B402Error(InvalidRecipient, …)`.
- 8 new vitest cases (round-trip representative + 32 random, tampered-checksum, wrong-HRP, out-of-range spend key, wrong-length view key, frozen reference vector, error-code surface). 12/12 SDK tests pass; SDK typecheck clean.

## Design decisions
- **Library:** `@scure/base` ^1.1.9 (added as direct SDK dep). The repo already had `bech32@1.1.4` transitively via ethers, but it's old/abandoned and not declared in `packages/sdk/package.json`. `@scure/base` is ESM-native, audited, and supports both bech32 / bech32m.
- **HRP:** `b402sol`, **deliberately distinct from any EVM-sibling HRP**. The issue offers a choice — share the HRP for cross-compat OR pick a Solana-specific one — and I picked the latter. Solana keys here are BN254 Fr (spending) + X25519 (viewing); EVM stealth addresses are secp256k1. Encoding two different key shapes under the same HRP would let a wallet silently accept an EVM stealth address as a Solana one and produce undeliverable notes. Distinct HRP forces explicit per-chain handling.
- **Versioning:** Single leading `0x00` byte preserves a forward-compat hook without committing to a specific upgrade scheme. Decoder rejects unknown versions explicitly so a future v1 won't be misread.
- **Canonical-only decode:** uses `leToFr` (rejects `>= FR_MODULUS`), not `leToFrReduced`, so two different strings can't decode to the same key.

## Test plan
- [x] `pnpm --filter @b402ai/solana test` — 12/12 pass (4 pre-existing borsh-roundtrip + 8 new stealth-address)
- [x] `pnpm --filter @b402ai/solana typecheck` — clean (after building `@b402ai/solana-prover` first, same as CI per commit `e5a1d5e`)
- [x] Frozen reference vector pinned in tests as a layout-regression canary

## Out of scope
- No wallet-level convenience that returns the encoded address straight from a `Wallet` object — kept narrow to the issue's encode/decode surface; happy to add as a follow-up if useful.
- No EVM cross-compat reference vector (chose the distinct-HRP branch of the issue's OR-condition with rationale above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)