### PR TITLE
adapter: Phoenix v1 Swap (Phase A of PRD-24)

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -9,11 +9,13 @@ skip-lint = false
 b402_pool = "42a3hsCXtQLWonyxWZosaaCJCweYYKMrvNd25p1Jrt2y"
 b402_verifier_transact = "Afjbnv2Ekxa98jjRw33xPPhZabevek2uZxoE75kr6ZrK"
 b402_jupiter_adapter = "3RHRcbinCmcj8JPBfVxb9FW76oh4r8y21aSx4JFy3yx7"
+b402_phoenix_adapter = "4CRu4g1wN1WgFoHwqKUpG9apALuWDmvTLoQ5x7SiCppo"
 
 [programs.devnet]
 b402_pool = "42a3hsCXtQLWonyxWZosaaCJCweYYKMrvNd25p1Jrt2y"
 b402_verifier_transact = "Afjbnv2Ekxa98jjRw33xPPhZabevek2uZxoE75kr6ZrK"
 b402_jupiter_adapter = "3RHRcbinCmcj8JPBfVxb9FW76oh4r8y21aSx4JFy3yx7"
+b402_phoenix_adapter = "4CRu4g1wN1WgFoHwqKUpG9apALuWDmvTLoQ5x7SiCppo"
 
 [registry]
 url = "https://api.apr.dev"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "b402-phoenix-adapter"
+version = "0.0.1"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "indexmap",
+]
+
+[[package]]
 name = "b402-pool"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "programs/b402-kamino-adapter",
     "programs/b402-orca-adapter",
     "programs/b402-adrena-adapter",
+    "programs/b402-phoenix-adapter",
     "packages/crypto",
 ]
 # `tests/onchain` is intentionally NOT in this workspace. It uses litesvm which

--- a/programs/b402-phoenix-adapter/Cargo.toml
+++ b/programs/b402-phoenix-adapter/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "b402-phoenix-adapter"
+version.workspace = true
+edition.workspace = true
+description = "b402 Phoenix v1 spot CLOB adapter (Phase A of PRD-24 — Swap only)"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "b402_phoenix_adapter"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang.workspace = true
+anchor-spl.workspace = true
+indexmap = { version = "=2.9.0" }
+
+[lints]
+workspace = true

--- a/programs/b402-phoenix-adapter/src/lib.rs
+++ b/programs/b402-phoenix-adapter/src/lib.rs
@@ -1,0 +1,303 @@
+//! b402_phoenix_adapter — Phoenix v1 spot CLOB adapter for the b402 shielded pool.
+//!
+//! **Phase A scope (PRD-24).** Single action variant: `Swap`. Phoenix v1's
+//! `Swap` (instruction tag = 0) is an Immediate-Or-Cancel taker order that
+//! requires no Seat, fills against the book at the current slot, and reverts
+//! the entire transaction if it cannot satisfy the OrderPacket's match
+//! limits. That synchronous, fill-or-revert shape maps cleanly onto the
+//! PRD-04 v1 ABI's post-CPI delta check — no shadow PDA, no delta-zero
+//! exemption, no two-phase claim. Phase B (`PlaceLimitOrder`, `Cancel*`,
+//! `WithdrawFunds`) lives in a separate crate revision once the maker-side
+//! infrastructure (PRD-13 + PRD-15) gets its first real consumer.
+//!
+//! ## ABI (PRD-04 §2)
+//!
+//! Pool calls `execute(in_amount, min_out_amount, action_payload)` after it
+//! has transferred `in_amount` of `in_mint` into `adapter_in_ta`. Adapter:
+//!   1. Borsh-decodes `PhoenixAction` from `action_payload`.
+//!   2. Forwards the inner Phoenix `Swap` instruction data opaquely to
+//!      Phoenix v1, signing as the adapter PDA.
+//!   3. Sweeps both `adapter_in_ta` (any unmatched residual) and
+//!      `adapter_out_ta` (matched output) back to the pool's vaults.
+//!
+//! Pool's post-CPI delta check enforces `out_vault.amount >= pre + min_out`.
+//! If the book is shallow and Phoenix matches less than `min_out_amount`,
+//! the transaction reverts whole — same shape as the Jupiter adapter's
+//! slippage failure.
+//!
+//! ## Why opaque forwarding (vs. a typed OrderPacket field set)
+//!
+//! Phoenix's `OrderPacket::ImmediateOrCancel` is 100+ bytes of nested Borsh.
+//! Re-encoding it inside the program adds zero security — the pool's
+//! `keccak(action_payload)` proof binding makes any relayer-side tampering
+//! equivalent to a forged proof — and adds a fragile maintenance surface to
+//! every Phoenix SDK upgrade. The b402 SDK builds the OrderPacket via
+//! `@ellipsis-labs/phoenix-sdk` off-chain; the adapter forwards the bytes
+//! verbatim. Same pattern as `b402-jupiter-adapter`'s opaque route forwarding.
+//!
+//! ## Out of scope for this crate
+//!
+//! - `PlaceLimitOrder` / `Cancel*` / `WithdrawFunds` (Phase B — needs PRD-13
+//!   shadow PDA + PRD-04 §7.1 delta-zero exemption).
+//! - Phoenix Rise perpetuals (Phase C — gated on Phoenix publishing a public
+//!   CPI surface; `docs.phoenix.trade/sdk/rise` is HTTP-first today).
+//! - Mainnet-fork integration test — lives in `examples/phoenix-adapter-fork-swap.ts`
+//!   in a follow-up PR; this crate's litesvm test only proves dispatch.
+
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Token, TokenAccount, Transfer};
+
+declare_id!("4CRu4g1wN1WgFoHwqKUpG9apALuWDmvTLoQ5x7SiCppo");
+
+/// Phoenix v1 program ID: PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY
+/// Verified against `Ellipsis-Labs/phoenix-v1` README (2026-04-28).
+/// Byte representation is base58-decoded from the address above.
+pub const PHOENIX_V1_PROGRAM_ID: Pubkey = Pubkey::new_from_array([
+    0x05, 0xd0, 0xea, 0x4f, 0x33, 0x73, 0x70, 0x13, 0xa5, 0x63, 0xe0, 0x93, 0x48, 0xed, 0xb6, 0xf4,
+    0x59, 0x3d, 0x91, 0xfc, 0x76, 0x41, 0xf9, 0x24, 0x7c, 0x24, 0x41, 0xa8, 0x42, 0xa1, 0xbb, 0xeb,
+]);
+
+/// Phoenix v1 instruction tag for `Swap` (variant 0 in `PhoenixInstruction`).
+/// Verified against the upstream `instruction.rs` enum at master (2026-04-28).
+pub const PHOENIX_IX_TAG_SWAP: u8 = 0;
+
+#[program]
+pub mod b402_phoenix_adapter {
+    use super::*;
+
+    /// Execute a Phoenix v1 action.
+    ///
+    /// `action_payload` Borsh-decodes into [`PhoenixAction`]. For Phase A
+    /// only `Swap` is accepted; any other variant is rejected at decode time.
+    ///
+    /// `remaining_accounts` carry the full Phoenix v1 `Swap` account list
+    /// in the published order (see `PHOENIX_SWAP_ACCOUNT_COUNT`):
+    ///
+    /// | # | Name             | Constraint                                 |
+    /// |---|------------------|--------------------------------------------|
+    /// | 0 | phoenix_program  | readonly                                   |
+    /// | 1 | log_authority    | readonly                                   |
+    /// | 2 | market           | writable                                   |
+    /// | 3 | trader           | signer (= adapter_authority)               |
+    /// | 4 | base_account     | writable (= adapter_in_ta or adapter_out_ta)|
+    /// | 5 | quote_account    | writable (= the other adapter scratch ATA) |
+    /// | 6 | base_vault       | writable (market PDA)                      |
+    /// | 7 | quote_vault      | writable (market PDA)                      |
+    /// | 8 | token_program    | readonly                                   |
+    pub fn execute(
+        ctx: Context<Execute>,
+        in_amount: u64,
+        min_out_amount: u64,
+        action_payload: Vec<u8>,
+    ) -> Result<()> {
+        // ABI sanity — match Jupiter adapter's pre-flight checks.
+        require!(in_amount > 0, PhoenixAdapterError::InvalidAmount);
+        require!(
+            !action_payload.is_empty(),
+            PhoenixAdapterError::InvalidActionPayload
+        );
+        require!(
+            ctx.accounts.adapter_in_ta.amount >= in_amount,
+            PhoenixAdapterError::InsufficientInput
+        );
+        require!(
+            ctx.remaining_accounts.len() == PHOENIX_SWAP_ACCOUNT_COUNT,
+            PhoenixAdapterError::InvalidRemainingAccounts
+        );
+
+        let action = PhoenixAction::try_from_slice(&action_payload)
+            .map_err(|_| PhoenixAdapterError::InvalidActionPayload)?;
+
+        match action {
+            PhoenixAction::Swap { phoenix_ix_data } => {
+                require!(
+                    !phoenix_ix_data.is_empty(),
+                    PhoenixAdapterError::InvalidActionPayload
+                );
+                require!(
+                    phoenix_ix_data[0] == PHOENIX_IX_TAG_SWAP,
+                    PhoenixAdapterError::WrongPhoenixIxTag
+                );
+
+                let phoenix_program_account = &ctx.remaining_accounts[0];
+                require_keys_eq!(
+                    *phoenix_program_account.key,
+                    PHOENIX_V1_PROGRAM_ID,
+                    PhoenixAdapterError::WrongPhoenixProgramId
+                );
+
+                // Snapshot pre-balances on both adapter scratch ATAs. The
+                // Swap moves residual input + matched output into them; we
+                // sweep the deltas back to pool vaults at the end.
+                let pre_in = ctx.accounts.adapter_in_ta.amount;
+                let pre_out = ctx.accounts.adapter_out_ta.amount;
+
+                // Build the CPI ix. Forward Phoenix's account list verbatim
+                // from remaining_accounts; mark the trader account (index 3)
+                // as a signer because the adapter PDA signs via invoke_signed
+                // for that role.
+                let auth_key = ctx.accounts.adapter_authority.key();
+                let metas: Vec<anchor_lang::solana_program::instruction::AccountMeta> = ctx
+                    .remaining_accounts
+                    .iter()
+                    .map(|a| {
+                        let is_signer = a.is_signer || *a.key == auth_key;
+                        if a.is_writable {
+                            anchor_lang::solana_program::instruction::AccountMeta::new(
+                                *a.key, is_signer,
+                            )
+                        } else {
+                            anchor_lang::solana_program::instruction::AccountMeta::new_readonly(
+                                *a.key, is_signer,
+                            )
+                        }
+                    })
+                    .collect();
+
+                let ix = anchor_lang::solana_program::instruction::Instruction {
+                    program_id: PHOENIX_V1_PROGRAM_ID,
+                    accounts: metas,
+                    data: phoenix_ix_data,
+                };
+
+                let authority_bump = ctx.bumps.adapter_authority;
+                let seeds: &[&[u8]] = &[b"b402/v1", b"adapter", &[authority_bump]];
+                let signer_seeds = &[seeds];
+
+                anchor_lang::solana_program::program::invoke_signed(
+                    &ix,
+                    ctx.remaining_accounts,
+                    signer_seeds,
+                )
+                .map_err(|_| PhoenixAdapterError::PhoenixCpiFailed)?;
+
+                // Sweep both scratch ATAs back. Phoenix's Swap can leave
+                // unmatched residual in adapter_in_ta if the book lacked depth.
+                let in_ta = &mut ctx.accounts.adapter_in_ta;
+                in_ta.reload()?;
+                let in_residual = in_ta.amount.saturating_sub(
+                    // Anything below pre_in that wasn't pulled out by Phoenix
+                    // (impossible under Phoenix's Swap semantics) is treated
+                    // as zero-residual.
+                    pre_in.saturating_sub(in_amount),
+                );
+                if in_residual > 0 {
+                    let cpi_accounts = Transfer {
+                        from: in_ta.to_account_info(),
+                        to: ctx.accounts.in_vault.to_account_info(),
+                        authority: ctx.accounts.adapter_authority.to_account_info(),
+                    };
+                    token::transfer(
+                        CpiContext::new_with_signer(
+                            ctx.accounts.token_program.to_account_info(),
+                            cpi_accounts,
+                            signer_seeds,
+                        ),
+                        in_residual,
+                    )?;
+                }
+
+                let out_ta = &mut ctx.accounts.adapter_out_ta;
+                out_ta.reload()?;
+                let post_out = out_ta.amount;
+                let received = post_out.saturating_sub(pre_out);
+                require!(
+                    received >= min_out_amount,
+                    PhoenixAdapterError::SlippageExceeded
+                );
+
+                if received > 0 {
+                    let cpi_accounts = Transfer {
+                        from: out_ta.to_account_info(),
+                        to: ctx.accounts.out_vault.to_account_info(),
+                        authority: ctx.accounts.adapter_authority.to_account_info(),
+                    };
+                    token::transfer(
+                        CpiContext::new_with_signer(
+                            ctx.accounts.token_program.to_account_info(),
+                            cpi_accounts,
+                            signer_seeds,
+                        ),
+                        received,
+                    )?;
+                }
+
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Phoenix v1 `Swap` requires exactly 9 accounts in the published order.
+pub const PHOENIX_SWAP_ACCOUNT_COUNT: usize = 9;
+
+/// Action variants exposed by this adapter. Borsh-encoded inside `action_payload`.
+///
+/// Phase A defines only `Swap`. The enum is kept variant-extensible so Phase B
+/// can add `PlaceLimitOrder` / `CancelOrdersById` / `WithdrawFunds` without an
+/// ABI rev — each new variant gets a fresh registry row with its own
+/// allowed-instruction discriminator.
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq, Eq)]
+pub enum PhoenixAction {
+    /// IOC taker swap. `phoenix_ix_data` is the full Phoenix v1 `Swap`
+    /// instruction data: leading tag byte (0x00 = `PHOENIX_IX_TAG_SWAP`) +
+    /// Borsh-encoded `OrderPacket::ImmediateOrCancel`. The b402 SDK builds
+    /// this off-chain via `@ellipsis-labs/phoenix-sdk`. The adapter does
+    /// not parse the OrderPacket — pool's `keccak(action_payload)` proof
+    /// binding makes byte-level tampering equivalent to a forged proof.
+    Swap { phoenix_ix_data: Vec<u8> },
+}
+
+#[derive(Accounts)]
+pub struct Execute<'info> {
+    /// CHECK: adapter PDA signer. Seeds checked at runtime.
+    #[account(
+        seeds = [b"b402/v1", b"adapter"],
+        bump,
+    )]
+    pub adapter_authority: UncheckedAccount<'info>,
+
+    /// Pool's input vault — adapter sweeps unmatched residual back here.
+    #[account(mut)]
+    pub in_vault: Account<'info, TokenAccount>,
+
+    /// Pool's output vault — adapter sweeps matched output here.
+    #[account(mut)]
+    pub out_vault: Account<'info, TokenAccount>,
+
+    /// Adapter-local scratch input token account. Authority = adapter PDA.
+    #[account(
+        mut,
+        constraint = adapter_in_ta.owner == adapter_authority.key(),
+    )]
+    pub adapter_in_ta: Account<'info, TokenAccount>,
+
+    /// Adapter-local scratch output token account. Authority = adapter PDA.
+    #[account(
+        mut,
+        constraint = adapter_out_ta.owner == adapter_authority.key(),
+    )]
+    pub adapter_out_ta: Account<'info, TokenAccount>,
+
+    pub token_program: Program<'info, Token>,
+}
+
+#[error_code]
+pub enum PhoenixAdapterError {
+    #[msg("invalid amount")]
+    InvalidAmount = 7000,
+    #[msg("invalid action payload")]
+    InvalidActionPayload = 7001,
+    #[msg("insufficient input in adapter account")]
+    InsufficientInput = 7002,
+    #[msg("Phoenix CPI failed")]
+    PhoenixCpiFailed = 7003,
+    #[msg("slippage exceeded")]
+    SlippageExceeded = 7004,
+    #[msg("invalid number of remaining accounts for Phoenix Swap")]
+    InvalidRemainingAccounts = 7005,
+    #[msg("remaining_accounts[0] is not the Phoenix v1 program")]
+    WrongPhoenixProgramId = 7006,
+    #[msg("phoenix_ix_data does not start with PHOENIX_IX_TAG_SWAP")]
+    WrongPhoenixIxTag = 7007,
+}

--- a/tests/onchain/tests/phoenix_swap.rs
+++ b/tests/onchain/tests/phoenix_swap.rs
@@ -1,0 +1,365 @@
+//! litesvm tests for `b402_phoenix_adapter::execute`.
+//!
+//! Same model as `kamino_deposit.rs`:
+//!   - Drive the adapter directly (without the pool) via litesvm.
+//!   - Assert the handler is wired correctly: Borsh decode succeeds,
+//!     ABI sanity checks pass, the Phoenix-side CPI is attempted under
+//!     the adapter PDA's signer seeds.
+//!
+//! What this test does NOT do:
+//!   - Run a real Phoenix v1 program. The PHOENIX_V1_PROGRAM_ID address is
+//!     NOT loaded in the litesvm — so the CPI fails, and the failure
+//!     proves dispatch reached Phoenix's program ID specifically.
+//!   - Drive a successful end-to-end Swap. Per PRD-24 Phase A §4.7 the
+//!     GREEN gate for happy-path is the mainnet-fork validator suite,
+//!     not litesvm. Building a Phoenix-protocol stub that correctly
+//!     loads market state, signs as `log_authority`, etc. is yak-shaving
+//!     vs. just running against the real program on a fork.
+//!
+//! What this DOES prove:
+//!   - The handler is no longer the pre-impl stub.
+//!   - The `PhoenixAction::Swap` variant Borsh-decodes through dispatch.
+//!   - The adapter routes the CPI to PHOENIX_V1_PROGRAM_ID specifically.
+//!   - The adapter's PDA seeds (`b"b402/v1", b"adapter"`) match the
+//!     pattern shared with every other b402 adapter.
+
+use b402_onchain_tests::{mint, program_path};
+use borsh::BorshSerialize;
+use litesvm::LiteSVM;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_message::Message;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+use std::str::FromStr;
+
+const PHOENIX_ADAPTER_ID_STR: &str = "4CRu4g1wN1WgFoHwqKUpG9apALuWDmvTLoQ5x7SiCppo";
+const PHOENIX_V1_PROGRAM_ID_STR: &str = "PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY";
+const TOKEN_PROGRAM_ID_STR: &str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+
+// Mirrors `b402_phoenix_adapter::PhoenixAdapterError` codes — kept inline
+// to avoid pulling the SBF crate's anchor-lang dep into this litesvm-only
+// crate (same rationale as kamino_deposit.rs).
+const ERR_INVALID_AMOUNT: u32 = 7000;
+const ERR_INVALID_ACTION_PAYLOAD: u32 = 7001;
+const ERR_INSUFFICIENT_INPUT: u32 = 7002;
+const ERR_INVALID_REMAINING_ACCOUNTS: u32 = 7005;
+const ERR_WRONG_PHOENIX_PROGRAM_ID: u32 = 7006;
+const ERR_WRONG_PHOENIX_IX_TAG: u32 = 7007;
+
+// Mirrors the Borsh enum tag of `PhoenixAction::Swap`.
+const PHOENIX_ACTION_SWAP: u8 = 0;
+// Mirrors `PHOENIX_IX_TAG_SWAP` in the adapter crate.
+const PHOENIX_IX_TAG_SWAP: u8 = 0;
+
+fn phoenix_adapter_id() -> Pubkey {
+    Pubkey::from_str(PHOENIX_ADAPTER_ID_STR).unwrap()
+}
+fn phoenix_v1_program_id() -> Pubkey {
+    Pubkey::from_str(PHOENIX_V1_PROGRAM_ID_STR).unwrap()
+}
+fn token_program_id() -> Pubkey {
+    Pubkey::from_str(TOKEN_PROGRAM_ID_STR).unwrap()
+}
+
+fn adapter_authority() -> Pubkey {
+    Pubkey::find_program_address(&[b"b402/v1", b"adapter"], &phoenix_adapter_id()).0
+}
+
+#[derive(BorshSerialize)]
+struct ExecuteArgs {
+    in_amount: u64,
+    min_out_amount: u64,
+    action_payload: Vec<u8>,
+}
+
+const EXECUTE_DISCRIMINATOR: [u8; 8] = [130, 221, 242, 154, 13, 193, 189, 29];
+
+/// Borsh-encode `PhoenixAction::Swap { phoenix_ix_data }`.
+fn encode_swap(phoenix_ix_data: Vec<u8>) -> Vec<u8> {
+    // Borsh enum: 1-byte tag + variant fields.
+    let mut v = vec![PHOENIX_ACTION_SWAP];
+    // Vec<u8> Borsh: u32 LE length prefix + bytes.
+    v.extend_from_slice(&(phoenix_ix_data.len() as u32).to_le_bytes());
+    v.extend_from_slice(&phoenix_ix_data);
+    v
+}
+
+struct Setup {
+    svm: LiteSVM,
+    caller: Keypair,
+    out_vault: Pubkey,
+    adapter_out_ta: Pubkey,
+    in_vault: Pubkey,
+    adapter_in_ta: Pubkey,
+}
+
+fn fresh_svm() -> Setup {
+    let mut svm = LiteSVM::new();
+    svm.add_program_from_file(phoenix_adapter_id(), program_path("b402_phoenix_adapter"))
+        .expect("deploy phoenix adapter");
+
+    let caller = Keypair::new();
+    svm.airdrop(&caller.pubkey(), 10_000_000_000).unwrap();
+
+    let auth = adapter_authority();
+
+    let in_mint = Pubkey::new_from_array([0xA1; 32]);
+    mint::plant_mint(&mut svm, &in_mint, &caller.pubkey(), 6);
+    let in_vault = Pubkey::new_from_array([0xB1; 32]);
+    mint::plant_token_account(&mut svm, &in_vault, &in_mint, &caller.pubkey(), 0);
+    let adapter_in_ta = Pubkey::new_from_array([0xC1; 32]);
+    mint::plant_token_account(&mut svm, &adapter_in_ta, &in_mint, &auth, 1_000_000);
+
+    let out_mint = Pubkey::new_from_array([0xA2; 32]);
+    mint::plant_mint(&mut svm, &out_mint, &caller.pubkey(), 6);
+    let out_vault = Pubkey::new_from_array([0xB2; 32]);
+    mint::plant_token_account(&mut svm, &out_vault, &out_mint, &caller.pubkey(), 0);
+    let adapter_out_ta = Pubkey::new_from_array([0xC2; 32]);
+    mint::plant_token_account(&mut svm, &adapter_out_ta, &out_mint, &auth, 0);
+
+    Setup {
+        svm,
+        caller,
+        out_vault,
+        adapter_out_ta,
+        in_vault,
+        adapter_in_ta,
+    }
+}
+
+fn send_execute(
+    setup: &mut Setup,
+    in_amount: u64,
+    min_out_amount: u64,
+    action_payload: Vec<u8>,
+    extra_remaining: Vec<AccountMeta>,
+) -> Result<(), litesvm::types::FailedTransactionMetadata> {
+    let args = ExecuteArgs {
+        in_amount,
+        min_out_amount,
+        action_payload,
+    };
+    let mut data = EXECUTE_DISCRIMINATOR.to_vec();
+    args.serialize(&mut data).unwrap();
+
+    let mut accounts = vec![
+        AccountMeta::new_readonly(adapter_authority(), false),
+        AccountMeta::new(setup.in_vault, false),
+        AccountMeta::new(setup.out_vault, false),
+        AccountMeta::new(setup.adapter_in_ta, false),
+        AccountMeta::new(setup.adapter_out_ta, false),
+        AccountMeta::new_readonly(token_program_id(), false),
+    ];
+    accounts.extend(extra_remaining);
+
+    let ix = Instruction {
+        program_id: phoenix_adapter_id(),
+        accounts,
+        data,
+    };
+    let cu = ComputeBudgetInstruction::set_compute_unit_limit(400_000);
+    let msg = Message::new(&[cu, ix], Some(&setup.caller.pubkey()));
+    let tx = Transaction::new(&[&setup.caller], msg, setup.svm.latest_blockhash());
+    setup.svm.send_transaction(tx).map(|_| ())
+}
+
+/// 9 placeholder accounts for the Phoenix v1 Swap call, in the published order
+/// (instruction.rs verified 2026-04-28). Index 0 must be the real Phoenix v1
+/// program ID for the adapter's pre-CPI check; the rest are arbitrary stubs.
+fn phoenix_swap_remaining_accounts() -> Vec<AccountMeta> {
+    vec![
+        // 0: phoenix_program (readonly) — must be the real ID for dispatch
+        AccountMeta::new_readonly(phoenix_v1_program_id(), false),
+        // 1: log_authority (readonly)
+        AccountMeta::new_readonly(Pubkey::new_from_array([0xE1; 32]), false),
+        // 2: market (writable)
+        AccountMeta::new(Pubkey::new_from_array([0xE2; 32]), false),
+        // 3: trader (signer = adapter_authority via invoke_signed)
+        AccountMeta::new_readonly(adapter_authority(), false),
+        // 4: base_account (writable)
+        AccountMeta::new(Pubkey::new_from_array([0xE4; 32]), false),
+        // 5: quote_account (writable)
+        AccountMeta::new(Pubkey::new_from_array([0xE5; 32]), false),
+        // 6: base_vault (writable)
+        AccountMeta::new(Pubkey::new_from_array([0xE6; 32]), false),
+        // 7: quote_vault (writable)
+        AccountMeta::new(Pubkey::new_from_array([0xE7; 32]), false),
+        // 8: token_program (readonly)
+        AccountMeta::new_readonly(token_program_id(), false),
+    ]
+}
+
+fn err_code_hex(code: u32) -> String {
+    format!("0x{code:x}")
+}
+
+#[test]
+fn swap_dispatches_and_attempts_phoenix_cpi() {
+    let mut setup = fresh_svm();
+
+    // Phoenix Swap ix data: leading tag byte 0x00 + arbitrary placeholder
+    // OrderPacket bytes. The adapter forwards opaquely; without Phoenix
+    // loaded the CPI fails at the unknown-program boundary regardless of
+    // the OrderPacket's well-formedness.
+    let mut phoenix_ix_data = vec![PHOENIX_IX_TAG_SWAP];
+    phoenix_ix_data.extend_from_slice(&[0u8; 64]);
+    let payload = encode_swap(phoenix_ix_data);
+
+    let res = send_execute(
+        &mut setup,
+        100_000,
+        0,
+        payload,
+        phoenix_swap_remaining_accounts(),
+    );
+
+    assert!(res.is_err(), "expected revert (no Phoenix program loaded)");
+    let err = res.unwrap_err();
+    let logs = err.meta.logs.join("\n");
+
+    let phoenix_id = PHOENIX_V1_PROGRAM_ID_STR;
+    let saw_unknown_program = logs.contains(&format!("Unknown program {phoenix_id}"));
+    let saw_unknown_account = logs.contains(&format!(
+        "Instruction references an unknown account {phoenix_id}"
+    ));
+    assert!(
+        saw_unknown_program || saw_unknown_account,
+        "expected runtime to reject CPI to Phoenix v1 program ID; logs:\n{logs}"
+    );
+    assert!(
+        !logs.contains(&err_code_hex(ERR_INVALID_ACTION_PAYLOAD))
+            && !logs.contains("InvalidActionPayload"),
+        "Borsh decode failed before reaching CPI; logs:\n{logs}"
+    );
+}
+
+#[test]
+fn invalid_payload_rejected_before_cpi() {
+    let mut setup = fresh_svm();
+
+    let res = send_execute(
+        &mut setup,
+        100,
+        0,
+        vec![0xff, 0xff, 0xff], // invalid Borsh enum tag
+        phoenix_swap_remaining_accounts(),
+    );
+
+    assert!(res.is_err(), "garbage payload must revert");
+    let err = res.unwrap_err();
+    let logs = err.meta.logs.join("\n");
+    assert!(
+        logs.contains(&err_code_hex(ERR_INVALID_ACTION_PAYLOAD))
+            || logs.contains("InvalidActionPayload"),
+        "expected InvalidActionPayload; logs:\n{logs}"
+    );
+}
+
+#[test]
+fn zero_in_amount_rejected() {
+    let mut setup = fresh_svm();
+    let payload = encode_swap(vec![PHOENIX_IX_TAG_SWAP, 0u8]);
+
+    let res = send_execute(&mut setup, 0, 0, payload, phoenix_swap_remaining_accounts());
+
+    assert!(res.is_err(), "zero in_amount must revert");
+    let err = res.unwrap_err();
+    let logs = err.meta.logs.join("\n");
+    assert!(
+        logs.contains(&err_code_hex(ERR_INVALID_AMOUNT)) || logs.contains("InvalidAmount"),
+        "expected InvalidAmount; logs:\n{logs}"
+    );
+}
+
+#[test]
+fn wrong_remaining_account_count_rejected() {
+    let mut setup = fresh_svm();
+    let payload = encode_swap(vec![PHOENIX_IX_TAG_SWAP]);
+
+    // Only 8 accounts instead of 9 — adapter must catch this before
+    // attempting to index remaining_accounts[0].
+    let mut short = phoenix_swap_remaining_accounts();
+    short.pop();
+
+    let res = send_execute(&mut setup, 100, 0, payload, short);
+    assert!(res.is_err(), "wrong account count must revert");
+    let err = res.unwrap_err();
+    let logs = err.meta.logs.join("\n");
+    assert!(
+        logs.contains(&err_code_hex(ERR_INVALID_REMAINING_ACCOUNTS))
+            || logs.contains("InvalidRemainingAccounts"),
+        "expected InvalidRemainingAccounts; logs:\n{logs}"
+    );
+}
+
+#[test]
+fn wrong_phoenix_program_id_rejected() {
+    let mut setup = fresh_svm();
+    let payload = encode_swap(vec![PHOENIX_IX_TAG_SWAP]);
+
+    let mut bogus = phoenix_swap_remaining_accounts();
+    // Replace remaining_accounts[0] (phoenix_program) with a non-Phoenix
+    // program ID. Adapter must reject before invoke_signed.
+    bogus[0] = AccountMeta::new_readonly(Pubkey::new_from_array([0xFF; 32]), false);
+
+    let res = send_execute(&mut setup, 100, 0, payload, bogus);
+    assert!(res.is_err(), "wrong phoenix program id must revert");
+    let err = res.unwrap_err();
+    let logs = err.meta.logs.join("\n");
+    assert!(
+        logs.contains(&err_code_hex(ERR_WRONG_PHOENIX_PROGRAM_ID))
+            || logs.contains("WrongPhoenixProgramId"),
+        "expected WrongPhoenixProgramId; logs:\n{logs}"
+    );
+}
+
+#[test]
+fn wrong_phoenix_ix_tag_rejected() {
+    let mut setup = fresh_svm();
+    // Phoenix ix data starting with tag 0x02 (PlaceLimitOrder) instead of 0x00.
+    // Phase A's adapter only accepts Swap (tag 0x00).
+    let payload = encode_swap(vec![0x02, 0u8, 0u8]);
+
+    let res = send_execute(
+        &mut setup,
+        100,
+        0,
+        payload,
+        phoenix_swap_remaining_accounts(),
+    );
+    assert!(res.is_err(), "wrong phoenix ix tag must revert");
+    let err = res.unwrap_err();
+    let logs = err.meta.logs.join("\n");
+    assert!(
+        logs.contains(&err_code_hex(ERR_WRONG_PHOENIX_IX_TAG))
+            || logs.contains("WrongPhoenixIxTag"),
+        "expected WrongPhoenixIxTag; logs:\n{logs}"
+    );
+}
+
+#[test]
+fn insufficient_input_rejected() {
+    let mut setup = fresh_svm();
+    let payload = encode_swap(vec![PHOENIX_IX_TAG_SWAP]);
+
+    // adapter_in_ta was funded with 1_000_000 in fresh_svm(); ask to spend
+    // 2_000_000.
+    let res = send_execute(
+        &mut setup,
+        2_000_000,
+        0,
+        payload,
+        phoenix_swap_remaining_accounts(),
+    );
+    assert!(res.is_err(), "insufficient input must revert");
+    let err = res.unwrap_err();
+    let logs = err.meta.logs.join("\n");
+    assert!(
+        logs.contains(&err_code_hex(ERR_INSUFFICIENT_INPUT)) || logs.contains("InsufficientInput"),
+        "expected InsufficientInput; logs:\n{logs}"
+    );
+}
+


### PR DESCRIPTION
## Summary
First implementation of the Phoenix adapter from PRD-24. Phase A only — the IOC `Swap` (Phoenix v1 instruction tag 0). Synchronous, fill-or-revert, no Seat required; ships under the existing PRD-04 v1 ABI with no spec changes. Modeled tightly on `b402-jupiter-adapter`.

- New crate `programs/b402-phoenix-adapter` (~300 LoC handler)
- Borsh `PhoenixAction::Swap { phoenix_ix_data: Vec<u8> }` — opaque forwarding (SDK builds the OrderPacket via `@ellipsis-labs/phoenix-sdk`)
- `invoke_signed` under the standard adapter PDA seeds (`b"b402/v1", b"adapter"`)
- Two-mint sweep: unmatched residual back to `in_vault`, matched output to `out_vault`
- 7 litesvm tests in `tests/onchain/tests/phoenix_swap.rs`
- Workspace + Anchor.toml registrations for the new program ID

## Tracks
- Closes #18 partially (Phase A only — Phase B for maker/limit comes later)
- Implements PRD-24 §4 (Phase A) — see PR #35 for the spec
- Spike issue #36

## Why opaque forwarding (not typed OrderPacket re-encoding)
Phoenix's `OrderPacket::ImmediateOrCancel` is 100+ bytes of nested Borsh. Re-encoding it inside the program adds zero security — the pool's `keccak(action_payload)` proof binding makes any relayer-side tampering equivalent to a forged proof — and adds a fragile maintenance surface to every Phoenix SDK upgrade. The enum is kept variant-extensible so Phase B (`PlaceLimitOrder` / `Cancel*` / `WithdrawFunds`) can land cleanly without an ABI rev.

## Test plan
- [x] `cargo check -p b402-phoenix-adapter` — clean
- [x] `cargo clippy -p b402-phoenix-adapter --no-deps -- -D warnings` — clean (1 unrelated warning is from a workspace-level lint allow-list referencing a clippy lint that older rustc doesn't recognize, identical to other adapters)
- [x] `cargo fmt -p b402-phoenix-adapter --check` — clean
- [ ] `cargo test --manifest-path tests/onchain/Cargo.toml --test phoenix_swap` — written but **not run on this machine**: the litesvm test crate's transitive `solana-*` deps require rustc 1.89+, but the SBF toolchain pins to 1.84.1. Identical mismatch hits any run from `main`. CI / a dev machine with rustc 1.89+ will run the suite cleanly.

## What this PR explicitly does NOT do
- **No mainnet-fork integration test.** That belongs in `examples/phoenix-adapter-fork-swap.ts` + `ops/setup-phoenix-fork.sh`, follow-up PR. The litesvm suite proves dispatch shape; the fork suite is the GREEN gate per PRD-24 §4.7.
- **No SDK wiring.** PRD-24 §7 specs `B402Solana.privateSwap({ venue: 'phoenix' })` — that's a separate PR once the adapter is on devnet.
- **No registry entry.** Adapter registration is a governance action; this PR ships the bytecode, not the on-chain register-adapter ix.

## Files
| Path | Purpose |
|---|---|
| `programs/b402-phoenix-adapter/Cargo.toml` | Crate metadata, mirrors Jupiter adapter |
| `programs/b402-phoenix-adapter/src/lib.rs` | Anchor program (`PhoenixAction`, `Execute`, `PhoenixAdapterError`) |
| `Cargo.toml` | Workspace member added |
| `Anchor.toml` | Program ID `4CRu4g1wN1WgFoHwqKUpG9apALuWDmvTLoQ5x7SiCppo` registered for localnet + devnet |
| `tests/onchain/tests/phoenix_swap.rs` | 7-test litesvm dispatch suite |

## Security checklist (PRD-04 §11)
1. **Does the downstream program transfer tokens out of anywhere owned by b402?** Only from `adapter_in_ta` / `adapter_out_ta` (adapter-owned scratch). Pool's vault is not exposed except via the controlled `in_amount` transfer that the pool itself does pre-CPI.
2. **Can the downstream program escalate privileges?** No account in the CPI carries pool signer authority. Adapter PDA is the only signer, and only for transfers from adapter-owned ATAs.
3. **Can downstream return a different mint than claimed?** `expected_out_mint` is bound in circuit + checked at the pool's post-CPI delta step.
4. **Can downstream fail silently with no revert?** Pool measures balance delta. Phoenix's Swap path is fill-or-revert by design (`order_packet.is_take_only()` enforced upstream), so the adapter never sees a half-filled-no-revert state.
5. **Does downstream do anything persistent that affects future swaps?** No — Swap (cross-only) is stateless from the adapter's view; no Seat, no TraderState side-effects. Phase B will introduce TraderState concerns; not relevant here.
6. **Oracle dependency?** None on the spot CLOB.
7. **Time-bomb / version coupling?** Phoenix v1 has been mainnet-stable since 2023 under BUSL-1.1. Tag-0 `Swap` semantics are part of the audited surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)