### PR TITLE
docs: align READMEs and PRDs with mainnet state at f588410

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,10 +22,10 @@ Private DeFi on Solana — shielded pool + Kamino/Drift/Jupiter/Orca composabili
 
 ## SDK API parity goal
 
-The Solana adapter must expose the same method surface as `@b402ai/sdk`:
-`shield`, `unshield`, `privateSwap`, `privateLend`, `privateRedeem`, `status`, `rebalance`,
-plus Solana-native additions once mainnet lands (`privatePerpOpen`/`privatePerpClose` for Drift,
-`privateLP` for Orca).
+The Solana adapter exposes the same method surface as `@b402ai/sdk`:
+`shield`, `unshield`, `privateSwap`, `privateLend`, `privateRedeem` (shipped in `@b402ai/solana@0.0.20`),
+`status`, `rebalance`. Solana-native additions next: `privatePerpOpen` /
+`privatePerpClose` for Drift, `privateLP` for Orca.
 
 ## Toolchain
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,16 @@ RPC_URL=https://api.devnet.solana.com pnpm --filter=@b402ai/solana-examples e2e
 Shield 100, unshield 100 to a fresh recipient. Sender and recipient share no
 on-chain edge.
 
-## Run private lending (mainnet-fork, ~2 minutes)
+## Run private lending (mainnet, live)
 
-Kamino isn't on devnet, so we boot a local validator with Kamino's mainnet
-program + USDC reserve + Pyth oracle cloned in. No real funds — the local
-validator mints alice 100 USDC.
+Kamino V2 USDC lend + redeem are exposed as `private_lend` / `private_redeem`
+through `@b402ai/solana@0.0.20` and `@b402ai/solana-mcp@0.0.27`. Each viewing
+key gets its own Kamino `Obligation` (PRD-33 per-user obligation, `owner_pda`
+derived from `outSpendingPub`). Verified end-to-end on mainnet:
+`private_lend` `4PVuzkJmFF2x...qoCR` (Finalized), `private_redeem`
+`279hTmsJ2y...c457` (Finalized).
+
+For mainnet-fork hacking against the same bytecode without spending real funds:
 
 ```bash
 ./ops/setup-kamino-fork.sh                            # clones state, boots validator
@@ -59,16 +64,11 @@ pnpm tsx examples/kamino-adapter-fork-deposit.ts      # private 1 USDC deposit
 Goes through `b402_kamino_adapter::execute` → 7 nested CPIs into Kamino
 (`init_user_metadata`, `init_obligation`, `init_obligation_farms_for_reserve`,
 `refresh_reserve`, `refresh_obligation`, `deposit_v2`, sweep). Obligation account
-grows 0 → 3,344 B in a single tx.
+grows 0 → 3,344 B in a single tx, owned by the per-user `owner_pda`.
 
-What this proves: real Kamino bytecode accepts the adapter's CPI sequence; the
-obligation is owned by the adapter PDA, not Alice — so Kamino's lending records
-reference the adapter PDA rather than the user wallet. What this does **not** prove:
-end-to-end pool-to-Kamino unlinkability. That requires shield → `adapt_execute` →
-adapter, where a relayer signs and the user's wallet doesn't appear in the tx
-at all. The pool path runs on devnet today through the mock adapter
-(`pnpm swap-e2e`); a Kamino-on-mainnet-fork variant of the same shielded path
-is the next integration milestone.
+Kamino lending currently exposed for the main USDC reserve only at the SDK/MCP
+layer. The adapter itself is reserve-generic; multi-market discovery is the
+next task.
 
 For the private swap variant (Jupiter v6 on mainnet-fork): [Quickstart](#quickstart)
 step 8. Instruction layout for `adapt_execute`: [`docs/TX-WALKTHROUGH.md`](docs/TX-WALKTHROUGH.md).
@@ -147,27 +147,30 @@ v2 ABI extension that makes this strictly true going forward.
 
 | Adapter | Status | What it enables |
 |---|---|---|
-| Jupiter v6 | devnet + mainnet-fork integration tests | private swap on any Jupiter route |
-| Kamino lend | mainnet-fork through `b402_kamino_adapter::execute` | private deposit (v0.1 alpha; withdraw / borrow / repay are gated to `NotYetImplemented` until mainnet-fork integration tests cover them) |
+| Jupiter v6 | mainnet (live) | private swap on any Jupiter route |
+| Kamino lend | mainnet (live) — `private_lend` + `private_redeem` on USDC reserve, per-user obligation | private deposit + redeem; borrow / repay handlers are scaffolded but gated `NotYetImplemented` |
 | Mock | live on devnet | adapter ABI invariant tests |
-| Adrena perps | scaffold; discriminators verified vs Adrena IDL | private leveraged trading (impl in progress) |
+| Adrena perps | scaffold; discriminators verified vs Adrena IDL | private leveraged trading |
 | Orca LP | scaffold | private whirlpool positions |
 | Jupiter perps | scaffold | private perps via JLP (request-queue model — pending v2 ABI two-phase claim notes) |
 | Drift perps | spec only | deferred pending Drift's post-hack reboot |
 
-## Devnet deployment
+## Mainnet deployment
 
 | Program | ID |
 |---|---|
-| Pool | `42a3hsCXtQLWonyxWZosaaCJCweYYKMrvNd25p1Jrt2y` |
+| Pool | `42a3hsCXtQLWonyxWZosaaCJCweYYKMrvNd25p1Jrt2y` (finalized slot 417871785, Path A slippage skip + Path B synthetic-mint input transfer skip + per_user_obligation) |
 | Verifier (transact) | `Afjbnv2Ekxa98jjRw33xPPhZabevek2uZxoE75kr6ZrK` |
 | Verifier (adapt) | `3Y2tyhNSaUiW5AcZcmFGRyTMdnroxHxc5GqFQPcMTZae` |
 | Jupiter adapter | `3RHRcbinCmcj8JPBfVxb9FW76oh4r8y21aSx4JFy3yx7` |
-| Kamino adapter | `2enwFgcGKJDqruHpCtvmhtxe3DYcV3k72VTvoGcdt2rX` |
+| Kamino adapter | `2enwFgcGKJDqruHpCtvmhtxe3DYcV3k72VTvoGcdt2rX` (finalized slot 417870483, `per_user_obligation` + `cpi-only` features) |
 | Mock adapter | `89kw33YDcbXfiayVNauz599LaDm51EuU8amWydpjYKgp` |
 | b402 ALT (16 entries) | `9FPYufa1KDkrn1VgfjkR7R667hbnTA7CNtmy38QcsuNj` |
 
-Mainnet alpha deployment in progress. See [`ops/mainnet-deploy.sh`](ops/mainnet-deploy.sh).
+Hosted relayer: Cloud Run revision `b402-solana-relayer-mainnet-00004-w5b`,
+exposes per-feature routes plus the generic `/relay/pool-ix` endpoint
+(any pool ix; auth + rate-limit enforced; `cfg.poolProgramId` operator-fixed).
+See [`ops/mainnet-deploy.sh`](ops/mainnet-deploy.sh).
 
 ## Privacy model
 
@@ -177,7 +180,7 @@ is the link between your wallet and your shielded actions:
 | Layer | What | Today |
 |---|---|---|
 | **L1: wallet ↔ action** | After shielding, your wallet isn't visible as the spend authority on subsequent shielded actions | a public-chain observer cannot cryptographically link a post-shield spend to the original wallet from the shielded action path alone — Groth16 proof binds the spend without revealing which note was spent |
-| **L2: action ↔ action** | Two shielded actions can't be trivially linked | broken at the note layer; per-user adapter PDAs land in v0.2 (helpers in `programs/b402-kamino-adapter/src/lib.rs` already, gated) |
+| **L2: action ↔ action** | Two shielded actions can't be trivially linked | broken at the note layer; per-user adapter PDAs live on mainnet via `per_user_obligation` (Kamino adapter slot 417870483) |
 | **L3: pool-level clustering** | Timing + amount correlation across the pool boundary | scales with anonymity set — small pool weak, large pool strong |
 
 **Defends against:** wallet-watching bots scraping mempool to copy
@@ -185,11 +188,12 @@ strategies, MEV searchers targeting public DEX flow, surveillance-grade
 indexers (Chainalysis, Nansen, Arkham) building wallet-level histories.
 Layer 1 unlinkability covers all of these.
 
-**Does NOT fully defend against (yet):** patient clustering analysts
-running timing-and-amount correlation across the pool boundary at small
-TVL. This is a fundamental property of UTXO-mixer constructions, not a
-b402-specific weakness. It's solved by adoption — every shield strengthens
-every other user's privacy. We cap alpha TVL while the anonymity set grows.
+**Does NOT fully defend against:** patient clustering analysts running
+timing-and-amount correlation across the pool boundary at small TVL.
+This is a fundamental property of UTXO-mixer constructions, not a
+b402-specific weakness. Mitigated by anonymity-set growth — every
+shield strengthens every other user's privacy. A soft TVL cap is
+enforced while the set grows.
 
 For autonomous agents specifically — where the adversary is automated
 strategy-copying bots, not patient analysts — Layer 1 is sufficient.
@@ -233,7 +237,8 @@ const unshieldRes = await b402.unshield({ to: recipientPubkey });    // spends t
 
 End-to-end runnable example: `examples/sdk-quick.ts`. Wraps wallet build,
 ATA derivation, tree fetch, and merkle-proof construction internally.
-`privateSwap` / `privateLend` / `redeem` on the same class — coming soon.
+`privateSwap`, `privateLend`, `privateRedeem` are exposed on the same class
+(shipped in `@b402ai/solana@0.0.20`).
 
 Lower-level building blocks (use these for paths the class doesn't cover yet):
 - `shield(params)` / `unshield(params)` — standalone action functions
@@ -325,7 +330,7 @@ b402-solana/
 │   ├── b402-verifier-transact/    Groth16 verifier, 18 PI (transact circuit)
 │   ├── b402-verifier-adapt/       Groth16 verifier, 23 PI (adapt circuit)
 │   ├── b402-jupiter-adapter/      Jupiter v6 CPI wrapper
-│   ├── b402-kamino-adapter/       Kamino lend CPI wrapper (deposit gated v0.1)
+│   ├── b402-kamino-adapter/       Kamino lend CPI wrapper (deposit + redeem live, per_user_obligation + cpi-only)
 │   ├── b402-mock-adapter/         test-only delta-invariant adapter
 │   ├── b402-adrena-adapter/       scaffold — perps, PRD-16
 │   ├── b402-orca-adapter/         scaffold — whirlpool LP
@@ -365,12 +370,15 @@ b402-solana/
 
 ## Status
 
-Alpha. Single-key admin during alpha → 3-of-5 multisig migration scheduled.
-Throwaway trusted-setup VK → multi-party ceremony in progress. External
-audits scoped with Veridise / Trail of Bits / Zellic — reports linked here
-when they land. Soft TVL cap during alpha; hard cap lands in `PoolConfig`
-before community-promoted deposits. Stealth-address bech32 encoding +
-production relayer hardening are next.
+Mainnet. Pool + verifiers + Jupiter adapter + Kamino adapter (per-user
+obligation) live; `private_swap`, `private_lend`, `private_redeem` proven
+end-to-end on mainnet with finalized signatures. Single-key admin today;
+3-of-5 multisig migration is the next operational milestone. Throwaway
+trusted-setup VK; multi-party ceremony pending. External audits scoped
+with Veridise / Trail of Bits / Zellic — reports linked here when they
+land. Soft TVL cap enforced; hard cap lands in `PoolConfig` before
+community-promoted deposits. Stealth-address bech32 encoding is the
+remaining SDK gap.
 
 Read the full [PRD set](docs/prds/) for the design rationale behind every
 decision. Issues + PRs welcome — adapter additions are the easiest contribution.

--- a/docs/prds/PRD-33-per-user-adapter-state.md
+++ b/docs/prds/PRD-33-per-user-adapter-state.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Phase 33.1 + 33.2 + 33.3 implemented (local fork, awaiting mainnet redeploy) |
+| **Status** | shipped mainnet @ slot 417870483 (PR #46, commit f588410) — Kamino adapter `2enwFgcGKJDqruHpCtvmhtxe3DYcV3k72VTvoGcdt2rX` carrying `per_user_obligation` + `cpi-only`, pool `42a3hsCXtQLWonyxWZosaaCJCweYYKMrvNd25p1Jrt2y` finalized at slot 417871785 with the matching Path A / Path B logic |
 | **Owner** | b402 core |
 | **Date** | 2026-05-02 (impl 2026-05-01) |
 | **Version** | 0.2 |
@@ -368,9 +368,14 @@ Solana's program-account model is the constraint that forces persistent per-user
 
 ---
 
-## 11. Implementation status as of 2026-05-01
+## 11. Implementation status
 
-### Shipped on `feat/phase-9-deploy` (local commits, NOT pushed)
+Shipped on mainnet at slot 417870483 (Kamino adapter) + 417871785 (pool),
+PR #46 / commit f588410. End-to-end verified: `private_lend`
+`4PVuzkJmFF2x...qoCR` (Finalized), `private_redeem`
+`279hTmsJ2y...c457` (Finalized).
+
+### Phase 33.1 + 33.2 + 33.3 (mainnet)
 
 **Phase 33.1 — pool-side forwarding** (`programs/b402-pool/src/instructions/adapt_execute.rs`):
 - Hardcoded `is_stateful_adapter(program_id)` const list — Kamino is the only entry today.
@@ -403,52 +408,16 @@ Solana's program-account model is the constraint that forces persistent per-user
 - **Liquidation-isolation Pyth-price simulation**: deferred to Phase 33.3.1 follow-up. Account-level isolation (this PR) is sufficient for the V1.0 ship gate — PDAs are independent on-chain accounts so a hypothetical liquidation can only touch the targeted obligation.
 - **AdapterRegistry `stateful_adapter` field**: rejected in favour of the const list (see §6.1 rationale). Drift / Marginfi adapters land via one-line edits to `is_stateful_adapter`.
 
-### Open questions for mayur to confirm before mainnet flip
+### Resolved before mainnet flip
 
-0. **BLOCKING — tx size ceiling discovered 2026-05-03.** Localnet fork test
-   surfaces that the per-user Kamino deposit tx OVERFLOWS the 1232 B v0-tx
-   cap. Compiled message has:
-   - 9 static keys × 32 B = 288 B (5 per-user PDAs forced static + 4 mandatory programs/signers)
-   - Phase 9 verifier ix data: 24 public inputs × 32 = 768 B + 256 B proof = 1024 B
-   - Plus message header, blockhash, sig array, ix metas
-   The combined tx serializes >1232 B even with full ALT compression of every
-   non-per-user-PDA. `MessageV0.serialize` throws "encoding overruns
-   Uint8Array" before the tx can be signed.
+0. **Tx size ceiling.** Resolved by PRD-35 (Groth16 public inputs moved out of ix data into a per-user `pending_inputs_pda`, written in tx 1, referenced in tx 2). Net per-call saving ~768 B; per-user Kamino deposit fits the 1232 B v0 cap with comfortable headroom.
+1. **Default flip timing.** Green-field — the mainnet adapter authority `J19LAUv7QvipsGqj2Z6VnEjL8p2Gs4er958Tkhd1okKT` had 0 SOL, 0 txs, 0 token accounts at flip time; no v0.1 shared obligation existed on mainnet. No drain, no migration.
+2. **Mainnet redeploy ordering.** Pool with `phase_9_dual_note` was already on mainnet (2026-04-30). Adapter with `per_user_obligation` + `cpi-only` was redeployed at slot 417870483; pool follow-up with Path A (slippage skip for stateful adapters) + Path B (synthetic-mint input transfer skip) finalized at slot 417871785.
+3. **`gc_obligation` admin model.** Body still returns `NotYetImplemented`. Decision deferred until first redeem path covers user-driven full exits in production; admin gating to be picked when the body is wired.
+4. **SDK exposure of `viewing_pub_hash` derivation.** Shipped in `@b402ai/solana@0.0.20` — `privateLend` / `privateRedeem` helpers auto-compute the per-user PDAs and inject them into `remainingAccounts`. Callers never see the PDA layout.
+5. **Adapter program-account-meta growth.** Confirmed in production: per-user `owner_pda` adds 1 account; ALT compresses the rest; serialized tx fits the v0 cap with PRD-35 inputs-out-of-ix-data in place.
 
-   Implication: adapter binary will deploy fine to mainnet, but the FIRST
-   real privateLend call will fail SDK-side. Cannot be discovered post-deploy
-   without a frozen window for users.
-
-   Solutions ranked:
-   - **(a) Phase 8 ALT auto-builder** — per-call ephemeral ALT extender that
-     loads the per-user PDAs into the existing ALT in the SAME tx via
-     `AddressLookupTableProgram::extendLookupTable`, then references them
-     via lookup. Net change: 5 per-user PDAs go from 5×32=160 B static to
-     5×1=5 B lookup, saving ~155 B. Would fit. Estimated effort: ~1-2 days.
-   - **(b) Pre-init per-user PDAs into a long-lived ALT** — every new user
-     extends the cluster's b402 ALT with their own 5 PDAs at first deposit.
-     ALT capacity is 256 entries (per ALT), so caps the per-cluster user
-     count at ~50 unique users per ALT. Multiple ALTs per cluster as
-     needed. Lower complexity than (a); higher per-user setup cost.
-   - **(c) Reduce Phase 9 public inputs** — re-derive `outSpendingPub` from
-     another input rather than expose it as a separate public input. Saves
-     32 B of ix data. Requires Phase 9.1 ceremony (~30 min) and adapter+
-     verifier-adapt redeploy. Borderline — might still not fit with
-     Kamino's 19-account remaining_accounts list.
-   - **(d) Split into two txs** — shield in tx1, kamino-deposit in tx2.
-     Loses atomicity. If tx2 fails the user holds a shielded USDC note but
-     the deposit-amount-bound proof was burned. Not acceptable.
-
-   Recommended: (a) Phase 8 ALT auto-builder. PRD-35 to be drafted as a
-   blocker on per-user Kamino mainnet flip.
-
-1. **Default flip timing.** ~~drain-and-upgrade~~ NO LONGER NEEDED — verified 2026-05-03 that the mainnet adapter authority `J19LAUv7QvipsGqj2Z6VnEjL8p2Gs4er958Tkhd1okKT` has 0 SOL, 0 transactions, 0 token accounts. The v0.1 shared obligation was never created on mainnet. Flip can ship per-user as the only path with no drain, no migration. Treat this as a green-field deploy.
-2. **Mainnet redeploy ordering.** Pool first or adapter first? Per §6.1, the rewrite is gated on `phase_9_dual_note` AND `is_stateful_adapter`. If adapter ships per-user first while pool is still on default-feature build, pool will forward unprefixed payload → adapter's `decode_per_user_payload` fails on length check → tx aborts. Safe ordering: **pool with `phase_9_dual_note` first** (already deployed mainnet 2026-04-30 per project_b402_solana_phase7_live), THEN adapter with `per_user_obligation`.
-3. **`gc_obligation` admin model.** Currently scaffolded as `admin: Signer` with no on-chain auth check. V1.0 wants either (a) restrict to `cfg.admin_multisig` (requires loading PoolConfig via CPI — adds 1 account) or (b) leave admin-open + rely on Kamino's own emptiness check (cheaper, looser). Pick before wiring the body.
-4. **SDK exposure of `viewing_pub_hash` derivation.** The fork test re-derives owner_pda from `wallet.spendingPub` inside the test. The SDK's privateLend/privateRedeem helpers should auto-compute the per-user PDAs and inject them into `remainingAccounts` so callers don't need to know about the PDA layout. Out of this PR (no SDK changes).
-5. **Adapter program-account-meta growth.** Per-user adds 1 account (owner_pda) to the `remaining_accounts` list. With Kamino's 19-account `ra_deposit`, the new layout has 20. ALT compresses the rest. Confirm wire size still <1232 B in the fork test on first run; if the per-user setup overflows, ALT-resident the per-user PDAs (cheap — they're stable per-user).
-
-### Commit graph (local, not pushed)
+### Commit graph
 
 ```
 49938d3 prd-33: per-user adapter state spec + failing TDD scaffold

--- a/docs/prds/PRD-34-program-hardening.md
+++ b/docs/prds/PRD-34-program-hardening.md
@@ -1,6 +1,6 @@
 # PRD-34 — Solana Program Hardening + Pre-Deploy Harness
 
-Status: drafted 2026-05-03. Author: mayur. Owner: protocol.
+Status: shipped mainnet @ slot 417870483 / 417871785 (PR #46, commit f588410). `pre-deploy-check.sh` + sub-scripts ran the gates that backed the kamino-adapter `per_user_obligation` + `cpi-only` redeploy and the matching pool redeploy. Author: mayur. Owner: protocol.
 
 ## 1. Problem
 

--- a/docs/prds/PRD-35-public-inputs-account.md
+++ b/docs/prds/PRD-35-public-inputs-account.md
@@ -1,9 +1,9 @@
 # PRD-35 — Move Groth16 public inputs from ix data to account data
 
-Status: drafted 2026-05-03. Author: mayur. Owner: protocol.
-Blocks: PRD-33 §11 q0 (per-user kamino mainnet flip), every future
+Status: shipped mainnet @ slot 417871785 (PR #46, commit f588410). Pool `42a3hsCXtQLWonyxWZosaaCJCweYYKMrvNd25p1Jrt2y` carries `commit_inputs` + the `pending_inputs` PDA pattern; `args.public_inputs` removed from the `adapt_execute` wire shape. `private_lend` / `private_redeem` mainnet runs (`4PVuzkJmFF2x...qoCR`, `279hTmsJ2y...c457`) confirm the 2-tx commit-then-verify path under the 1232 B v0 cap. Author: mayur. Owner: protocol.
+Unblocks: PRD-33 per-user Kamino on mainnet (now live), every future
 adapter that touches a stateful protocol (Drift, Marginfi, Adrena,
-Sanctum LST, Orca whirlpool, pump.fun if/when integrated).
+Sanctum LST, Orca whirlpool).
 
 ## 1. The architectural ceiling we're hitting
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -19,6 +19,8 @@ Then in any Claude Code session: `"What's my private balance on b402?"` → tool
 | `shield` | Move SPL tokens from the wallet into a private balance |
 | `unshield` | Withdraw a private deposit to a public address |
 | `private_swap` | Atomic private swap through a registered adapter (Jupiter on mainnet, mock on devnet) |
+| `private_lend` | Atomic private USDC deposit into Kamino V2 (mainnet only): spends a shielded USDC note, deposits into Kamino, mints a kUSDC voucher commitment in one tx. Each viewing key gets its own Kamino Obligation (PRD-33 per-user obligation). First call by a viewing key pays a one-time ~0.04 SOL for UserMetadata + Obligation rent. |
+| `private_redeem` | Atomic Kamino V2 → private USDC (mainnet only): burns a kUSDC voucher minted by a prior `private_lend`, withdraws the underlying USDC from the per-user obligation, reshields the proceeds as a fresh USDC note. |
 | `status` | Wallet pubkey + private balances by mint |
 | `holdings` | Per-deposit private holdings (id, mint, amount) |
 | `balance` | Aggregate private balance per mint |

--- a/packages/relayer/README.md
+++ b/packages/relayer/README.md
@@ -70,12 +70,20 @@ Pass via `Authorization: Bearer kp_3f9b1a2c0d4e6f78` or `x-api-key: ...`.
 
 ## Endpoints
 
+| Route | Forwards to | Notes |
+|---|---|---|
+| `POST /relay/shield` | pool `shield` | Fee-extracting; per-feature checks. |
+| `POST /relay/unshield` | pool `unshield` | Fee-extracting; per-feature checks. |
+| `POST /relay/transact` | pool `transact` | Fee-extracting; per-feature checks. |
+| `POST /relay/adapt` | pool `adapt_execute` | Adapter allowlist enforced (`JUPITER_ADAPTER_ID` / `MOCK_ADAPTER_ID` / `EXTRA_ADAPTER_IDS`). |
+| `POST /relay/pool-ix` | any pool ix targeting `cfg.poolProgramId` | Generic; no fee floor (for pool-internal ixs without a fee field, e.g. PRD-35 `commit_inputs`). Auth + rate-limit still enforced. `programId` is taken from operator config, never from the request body. |
+
 All relay endpoints share one body shape and one response shape.
 
 ### Request
 
 ```ts
-POST /relay/{shield|unshield|transact|adapt}
+POST /relay/{shield|unshield|transact|adapt|pool-ix}
 Content-Type: application/json
 Authorization: Bearer <api-key>
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -11,6 +11,8 @@ npm install @b402ai/solana
 - **Shield** SPL tokens into a private balance
 - **Unshield** to any public address
 - **Private swap** through registered adapters (Jupiter on mainnet, mock on devnet)
+- **Private lend** USDC into Kamino V2 from a shielded note (per-user obligation, mainnet)
+- **Private redeem** a kUSDC voucher back into a shielded USDC note (mainnet)
 - **Read** your private balance / per-deposit holdings without leaking ZK plumbing
 - **Watch** for new private deposits via cursor-based polling
 - **Quote** swaps via Jupiter Lite API before executing


### PR DESCRIPTION
Reflect the mainnet-shipped reality merged in #46. Pure engineering tone. No marketing hedges.

## Changes
- README.md: drop \"v0.1 alpha\" / \"next milestone\" framing for shipped features (privateLend, privateRedeem, /relay/pool-ix, per_user_obligation). Cite live program IDs + slots, npm versions, Finalized signatures.
- packages/sdk/README.md: list privateLend + privateRedeem.
- packages/mcp-server/README.md: add private_lend + private_redeem to tools table.
- packages/relayer/README.md: add /relay/pool-ix.
- PRD-33 / PRD-34 / PRD-35: status headers updated from \"drafted\" / \"awaiting mainnet\" to \"shipped mainnet @ slot X (PR #46, commit f588410)\". Design content untouched.
- CLAUDE.md: SDK API parity goal marks privateLend / privateRedeem as shipped in @b402ai/solana@0.0.20.

## Test plan
- [x] Doc accuracy verified against on-chain state (slot 417870483 / 417871785)
- [x] No code changes; CI should pass on existing checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)