### PR TITLE
Multi-market Kamino + WS-fallback poll-confirm + per-(viewing_key, mint) obligations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ examples/mainnet-jupiter-swap-demo.ts
 examples/mainnet-phase7-smoke.ts
 examples/mainnet-end-to-end-demo.ts
 examples/mainnet-swap-matrix.ts
+examples/mainnet-add-token-cfg.mjs
 examples/probe-*.mjs
 examples/surfpool-bench.mjs
 examples/devnet-phase7-smoke.ts

--- a/packages/mcp-server/src/kamino-helpers.ts
+++ b/packages/mcp-server/src/kamino-helpers.ts
@@ -136,9 +136,13 @@ export function obligationFarmPda(farm: PublicKey, obligation: PublicKey): Publi
   )[0];
 }
 
-export function deriveOwnerPda(adapter: PublicKey, hash: Buffer): PublicKey {
+/** Per-(viewing_key, mint) PDA — matches the adapter's `derive_owner_pda`
+ *  in programs/b402-kamino-adapter/src/lib.rs. Each lending position
+ *  keyed by liquidity mint gets its own Kamino UserMetadata + Obligation,
+ *  so positions across mints are structurally independent. */
+export function deriveOwnerPda(adapter: PublicKey, hash: Buffer, mint: PublicKey): PublicKey {
   return PublicKey.findProgramAddressSync(
-    [Buffer.from('b402/v1'), Buffer.from('adapter-owner'), hash], adapter,
+    [Buffer.from('b402/v1'), Buffer.from('adapter-owner'), hash, mint.toBuffer()], adapter,
   )[0];
 }
 
@@ -218,7 +222,7 @@ export function deriveAllPerUser(
   market: PublicKey,
 ): PerUserAccounts {
   const hash = spendingPubToHashBytes(spendingPub);
-  const ownerPda = deriveOwnerPda(KAMINO_ADAPTER, hash);
+  const ownerPda = deriveOwnerPda(KAMINO_ADAPTER, hash, reserve.liquidityMint);
   const isFarmAttached = !reserve.reserveFarmCollateral.equals(PublicKey.default);
   const obl = obligationPda(ownerPda, market);
   return {

--- a/packages/mcp-server/src/kamino-helpers.ts
+++ b/packages/mcp-server/src/kamino-helpers.ts
@@ -19,14 +19,12 @@ import {
   PublicKey,
   SystemProgram,
   Transaction,
-  sendAndConfirmTransaction,
   type AccountMeta,
 } from '@solana/web3.js';
 import {
   TOKEN_PROGRAM_ID,
   createAssociatedTokenAccountIdempotentInstruction,
   getAssociatedTokenAddressSync,
-  getOrCreateAssociatedTokenAccount,
 } from '@solana/spl-token';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -63,6 +61,43 @@ const ALT_PROGRAM = new PublicKey('AddressLookupTab1e1111111111111111111111111')
 const EXECUTE_DISC = Uint8Array.from([130, 221, 242, 154, 13, 193, 189, 29]);
 
 // ── small helpers ─────────────────────────────────────────────────────────────
+/**
+ * Send + confirm a tx without WebSocket subscriptions. web3.js's
+ * `sendAndConfirmTransaction` uses confirmTransaction's WS-based path,
+ * which on Helius free tier returns 429 on the WS upgrade after a few
+ * subs and never delivers the confirmation event — leaving txs to
+ * "expire" even when they Finalized 30s prior. Poll instead.
+ */
+async function sendAndPollConfirm(
+  conn: Connection,
+  tx: Transaction,
+  signers: Keypair[],
+  timeoutMs: number = 90_000,
+): Promise<string> {
+  const bh = await conn.getLatestBlockhash('confirmed');
+  tx.recentBlockhash = bh.blockhash;
+  tx.feePayer = signers[0].publicKey;
+  tx.sign(...signers);
+  const sig = await conn.sendRawTransaction(tx.serialize(), {
+    skipPreflight: false,
+    preflightCommitment: 'confirmed',
+    maxRetries: 3,
+  });
+  const start = Date.now();
+  let interval = 2000;
+  while (Date.now() - start < timeoutMs) {
+    const res = await conn.getSignatureStatuses([sig], { searchTransactionHistory: false });
+    const s = res.value[0];
+    if (s) {
+      if (s.err) throw new Error(`tx ${sig} failed: ${JSON.stringify(s.err)}`);
+      if (s.confirmationStatus === 'confirmed' || s.confirmationStatus === 'finalized') return sig;
+    }
+    await new Promise((r) => setTimeout(r, interval));
+    interval = Math.min(interval * 1.2, 5000);
+  }
+  throw new Error(`tx ${sig} not confirmed within ${timeoutMs / 1000}s`);
+}
+
 function findUtf8(buf: Buffer, needle: string): number {
   const b = Buffer.from(needle, 'utf8');
   for (let i = 0; i < buf.length - b.length; i++) {
@@ -297,7 +332,7 @@ export async function ensureAlt(args: {
     });
     altPubkey = fresh;
     altIsFresh = true;
-    await sendAndConfirmTransaction(args.conn, new Transaction().add(createIx), [args.admin], { commitment: 'finalized' });
+    await sendAndPollConfirm(args.conn, new Transaction().add(createIx), [args.admin]);
     // Wait for ALT to be finalized + visible.
     for (let i = 0; i < 60; i++) {
       const info = await args.conn.getAccountInfo(altPubkey, 'finalized');
@@ -329,7 +364,7 @@ export async function ensureAlt(args: {
         payer: args.admin.publicKey, authority: args.admin.publicKey, lookupTable: altPubkey,
         addresses: targets.slice(i, i + CHUNK),
       });
-      await sendAndConfirmTransaction(args.conn, new Transaction().add(ext), [args.admin], { commitment: 'confirmed' });
+      await sendAndPollConfirm(args.conn, new Transaction().add(ext), [args.admin]);
     }
     // Brief wait so the next tx can resolve via the new entries.
     await new Promise((r) => setTimeout(r, 4000));
@@ -351,7 +386,7 @@ export async function ensurePerUserSetup(args: {
   let adapterFunded = false;
   const aaBal = await args.conn.getBalance(args.adapterAuthority);
   if (aaBal < 0.05 * LAMPORTS_PER_SOL) {
-    await sendAndConfirmTransaction(args.conn,
+    await sendAndPollConfirm(args.conn,
       new Transaction().add(
         SystemProgram.transfer({
           fromPubkey: args.admin.publicKey,
@@ -359,7 +394,7 @@ export async function ensurePerUserSetup(args: {
           lamports: 0.5 * LAMPORTS_PER_SOL,
         }),
       ),
-      [args.admin], { commitment: 'confirmed' },
+      [args.admin],
     );
     adapterFunded = true;
   }
@@ -372,7 +407,7 @@ export async function ensurePerUserSetup(args: {
       args.admin.publicKey, args.perUser.ownerUsdcAta,
       args.perUser.ownerPda, args.reserve.liquidityMint,
     );
-    await sendAndConfirmTransaction(args.conn, new Transaction().add(createAtaIx), [args.admin], { commitment: 'confirmed' });
+    await sendAndPollConfirm(args.conn, new Transaction().add(createAtaIx), [args.admin]);
     ataCreated = true;
   }
 
@@ -387,13 +422,24 @@ export async function ensureAdapterScratchAtas(args: {
   inMint: PublicKey;
   outMint: PublicKey;
 }): Promise<{ adapterInTa: PublicKey; adapterOutTa: PublicKey }> {
-  const inAcc = await getOrCreateAssociatedTokenAccount(
-    args.conn, args.admin, args.inMint, args.adapterAuthority, true,
-  );
-  const outAcc = await getOrCreateAssociatedTokenAccount(
-    args.conn, args.admin, args.outMint, args.adapterAuthority, true,
-  );
-  return { adapterInTa: inAcc.address, adapterOutTa: outAcc.address };
+  const inAta = getAssociatedTokenAddressSync(args.inMint, args.adapterAuthority, true);
+  const outAta = getAssociatedTokenAddressSync(args.outMint, args.adapterAuthority, true);
+  // Idempotent create — both ATAs in one tx if either is missing. Anyone
+  // can pay rent for an ATA owned by anyone else (PDA in this case).
+  const ixs = [];
+  const [inInfo, outInfo] = await Promise.all([
+    args.conn.getAccountInfo(inAta), args.conn.getAccountInfo(outAta),
+  ]);
+  if (!inInfo) ixs.push(createAssociatedTokenAccountIdempotentInstruction(
+    args.admin.publicKey, inAta, args.adapterAuthority, args.inMint,
+  ));
+  if (!outInfo) ixs.push(createAssociatedTokenAccountIdempotentInstruction(
+    args.admin.publicKey, outAta, args.adapterAuthority, args.outMint,
+  ));
+  if (ixs.length > 0) {
+    await sendAndPollConfirm(args.conn, new Transaction().add(...ixs), [args.admin]);
+  }
+  return { adapterInTa: inAta, adapterOutTa: outAta };
 }
 
 // ── ix data builders (deposit / withdraw) ─────────────────────────────────────

--- a/packages/mcp-server/src/kamino-helpers.ts
+++ b/packages/mcp-server/src/kamino-helpers.ts
@@ -130,15 +130,21 @@ export interface ParsedReserve {
   reserveFarmCollateral: PublicKey;
 }
 
-/** Parse a Kamino reserve account's on-chain layout. The byte offsets here
- *  are derived from the kLend Reserve struct. Mainnet-USDC-tested. */
-export function parseReserve(data: Buffer): ParsedReserve {
-  const liquidityMint = new PublicKey(data.subarray(128, 160));
-  const reserveFarmCollateral = new PublicKey(data.subarray(64, 96));
-  let nameOff = findUtf8(data, 'USDC\0');
-  if (nameOff < 0) nameOff = findUtf8(data, 'USD Coin');
-  if (nameOff < 0) throw new Error('TokenInfo.name not found in reserve');
-  const tokenInfoOff = nameOff;
+/** Reserve struct field offsets shared with the SDK's kamino-discover. */
+const RESERVE_LIQUIDITY_MINT_OFFSET = 128;
+const RESERVE_FARM_COLLATERAL_OFFSET = 64;
+const RESERVE_TOKEN_INFO_NAME_OFFSET = 5032;
+
+/** Parse a Kamino reserve account into the per-reserve PDAs the adapter
+ *  needs. Uses fixed struct offsets only — no string-anchor search, so
+ *  it works for any mint (USDC, SOL, JitoSOL, BONK, …). The `market`
+ *  argument is required because the per-reserve sub-PDAs (liquidity
+ *  supply, collateral mint, etc.) are derived from `(market, mint)`. */
+export function parseReserve(data: Buffer, market: PublicKey): ParsedReserve {
+  const liquidityMint = new PublicKey(data.subarray(RESERVE_LIQUIDITY_MINT_OFFSET, RESERVE_LIQUIDITY_MINT_OFFSET + 32));
+  const reserveFarmCollateral = new PublicKey(data.subarray(RESERVE_FARM_COLLATERAL_OFFSET, RESERVE_FARM_COLLATERAL_OFFSET + 32));
+  const tokenInfoOff = RESERVE_TOKEN_INFO_NAME_OFFSET;
+  // Within TokenInfo: name(32) + heuristic(24) + maxAgePriceSeconds(8) + maxAgeTwapSeconds(8) + scopeConfig(...)
   const scopeOff = tokenInfoOff + 32 + 24 + 24;
   const swbOff = scopeOff + 52;
   const pythOff = swbOff + 68;
@@ -149,9 +155,9 @@ export function parseReserve(data: Buffer): ParsedReserve {
   };
   return {
     liquidityMint,
-    liquiditySupply: reservePda('reserve_liq_supply', MARKET, liquidityMint),
-    collateralMint: reservePda('reserve_coll_mint', MARKET, liquidityMint),
-    collateralReserveDestSupply: reservePda('reserve_coll_supply', MARKET, liquidityMint),
+    liquiditySupply: reservePda('reserve_liq_supply', market, liquidityMint),
+    collateralMint: reservePda('reserve_coll_mint', market, liquidityMint),
+    collateralReserveDestSupply: reservePda('reserve_coll_supply', market, liquidityMint),
     pyth: readPk(pythOff),
     switchboardPrice: readPk(swbOff),
     switchboardTwap: readPk(swbOff + 32),
@@ -174,23 +180,36 @@ export interface PerUserAccounts {
 export function deriveAllPerUser(
   spendingPub: bigint,
   reserve: ParsedReserve,
+  market: PublicKey,
 ): PerUserAccounts {
   const hash = spendingPubToHashBytes(spendingPub);
   const ownerPda = deriveOwnerPda(KAMINO_ADAPTER, hash);
   const isFarmAttached = !reserve.reserveFarmCollateral.equals(PublicKey.default);
+  const obl = obligationPda(ownerPda, market);
   return {
     ownerPda,
     userMetadata: userMetadataPda(ownerPda),
-    obligation: obligationPda(ownerPda, MARKET),
-    obligationFarm: isFarmAttached ? obligationFarmPda(reserve.reserveFarmCollateral, obligationPda(ownerPda, MARKET)) : KLEND,
+    obligation: obl,
+    obligationFarm: isFarmAttached ? obligationFarmPda(reserve.reserveFarmCollateral, obl) : KLEND,
     reserveFarmState: isFarmAttached ? reserve.reserveFarmCollateral : KLEND,
+    // Per-mint user ATA owned by ownerPda — was named `ownerUsdcAta` for the
+    // initial USDC-only flow but works for any mint via `reserve.liquidityMint`.
     ownerUsdcAta: getAssociatedTokenAddressSync(reserve.liquidityMint, ownerPda, true),
     isFarmAttached,
   };
 }
 
 // ── ALT bootstrap ─────────────────────────────────────────────────────────────
-const ALT_PERSIST_DEFAULT = path.join(os.homedir(), '.b402-solana', 'kamino-mainnet-alt.json');
+/** Persist one ALT per (market, mint) tuple. Different markets/mints have
+ *  disjoint reserve sub-PDAs; sharing one ALT across mints would force
+ *  re-extends on every switch, eating the 256-entry ALT cap fast. */
+function altPersistPathFor(market: PublicKey, mint: PublicKey): string {
+  return path.join(
+    os.homedir(),
+    '.b402-solana',
+    `kamino-mainnet-alt-${market.toBase58().slice(0, 8)}-${mint.toBase58().slice(0, 8)}.json`,
+  );
+}
 
 /** Load (or create + extend) the persisted ALT for Kamino lend/redeem. The
  *  ALT contains all the static and per-user accounts that the lend/redeem
@@ -198,6 +217,8 @@ const ALT_PERSIST_DEFAULT = path.join(os.homedir(), '.b402-solana', 'kamino-main
 export async function ensureAlt(args: {
   conn: Connection;
   admin: Keypair;
+  market: PublicKey;
+  reserveAddr: PublicKey;
   reserve: ParsedReserve;
   perUser: PerUserAccounts;
   pendingInputsPda: PublicKey;
@@ -214,7 +235,7 @@ export async function ensureAlt(args: {
   };
   altPersistPath?: string;
 }): Promise<PublicKey> {
-  const persistPath = args.altPersistPath ?? ALT_PERSIST_DEFAULT;
+  const persistPath = args.altPersistPath ?? altPersistPathFor(args.market, args.reserve.liquidityMint);
   fs.mkdirSync(path.dirname(persistPath), { recursive: true });
 
   const NULLIFIER_CPI_AUTHORITY = PublicKey.findProgramAddressSync(
@@ -238,7 +259,7 @@ export async function ensureAlt(args: {
     VERIFIER_A,
     KAMINO_ADAPTER, args.adapterAuthority,
     args.adapterInTa, args.adapterOutTa,
-    RESERVE, MARKET, lendingMarketAuthorityPda(MARKET),
+    args.reserveAddr, args.market, lendingMarketAuthorityPda(args.market),
     args.reserve.liquiditySupply, args.reserve.collateralMint,
     args.reserve.collateralReserveDestSupply,
     args.reserve.pyth ?? KLEND, args.reserve.switchboardPrice ?? KLEND,
@@ -411,15 +432,17 @@ export function buildAdapterIxData(inAmount: bigint, expectedOut: bigint, payloa
 
 // ── remaining_accounts builders ──────────────────────────────────────────────
 export function buildDepositRemainingAccounts(args: {
+  market: PublicKey;
+  reserveAddr: PublicKey;
   reserve: ParsedReserve;
   perUser: PerUserAccounts;
 }): AccountMeta[] {
   const { reserve, perUser } = args;
   const isFarm = perUser.isFarmAttached;
   return [
-    { pubkey: RESERVE, isSigner: false, isWritable: true },
-    { pubkey: MARKET, isSigner: false, isWritable: false },
-    { pubkey: lendingMarketAuthorityPda(MARKET), isSigner: false, isWritable: false },
+    { pubkey: args.reserveAddr, isSigner: false, isWritable: true },
+    { pubkey: args.market, isSigner: false, isWritable: false },
+    { pubkey: lendingMarketAuthorityPda(args.market), isSigner: false, isWritable: false },
     { pubkey: reserve.liquiditySupply, isSigner: false, isWritable: true },
     { pubkey: reserve.collateralMint, isSigner: false, isWritable: true },
     { pubkey: reserve.collateralReserveDestSupply, isSigner: false, isWritable: true },
@@ -442,16 +465,18 @@ export function buildDepositRemainingAccounts(args: {
 }
 
 export function buildWithdrawRemainingAccounts(args: {
+  market: PublicKey;
+  reserveAddr: PublicKey;
   reserve: ParsedReserve;
   perUser: PerUserAccounts;
 }): AccountMeta[] {
   const { reserve, perUser } = args;
   const isFarm = perUser.isFarmAttached;
   return [
-    { pubkey: RESERVE, isSigner: false, isWritable: true },                                  // 0
+    { pubkey: args.reserveAddr, isSigner: false, isWritable: true },                         // 0
     { pubkey: perUser.obligation, isSigner: false, isWritable: true },                       // 1
-    { pubkey: MARKET, isSigner: false, isWritable: false },                                  // 2
-    { pubkey: lendingMarketAuthorityPda(MARKET), isSigner: false, isWritable: false },       // 3
+    { pubkey: args.market, isSigner: false, isWritable: false },                             // 2
+    { pubkey: lendingMarketAuthorityPda(args.market), isSigner: false, isWritable: false },  // 3
     { pubkey: reserve.collateralReserveDestSupply, isSigner: false, isWritable: true },      // 4
     { pubkey: reserve.collateralMint, isSigner: false, isWritable: true },                   // 5
     { pubkey: reserve.liquiditySupply, isSigner: false, isWritable: true },                  // 6

--- a/packages/mcp-server/src/schemas.ts
+++ b/packages/mcp-server/src/schemas.ts
@@ -95,14 +95,18 @@ export const watchIncomingInput = z
 
 export const privateLendInput = z
   .object({
-    amount: U64String.describe('USDC amount to lend, in raw units (6 decimals — e.g. 100000 = 0.10 USDC, 1000000 = 1.00 USDC). Mainnet only. The caller must already hold a spendable shielded USDC note ≥ this amount; if a note matching the exact amount exists, it will be used, otherwise the most-recent spendable USDC note is selected. First call by a viewing key pays a one-time ~0.04 SOL for Kamino UserMetadata + Obligation rent (charged to adapter authority pre-funded by the user).'),
-    leafIndex: z.number().int().nonnegative().optional().describe('Optional Merkle leaf index of the specific USDC note to spend. Omit to auto-pick (exact-amount match → most-recent fallback).'),
+    amount: U64String.describe('Amount to lend in raw units (smallest token denomination). E.g. for USDC (6 decimals), 1000000 = 1.00 USDC; for SOL (9 decimals), 1000000000 = 1.00 SOL. Caller must hold a spendable shielded note ≥ this amount in `mint`.'),
+    mint: Base58Pubkey.optional().describe('SPL mint to lend. Default USDC mainnet (EPjFWdd5...). Pass any mint Kamino supports (SOL, JitoSOL, USDT, BONK, etc.) — the reserve is discovered on-chain via `pickBestKaminoReserveByMint`.'),
+    market: Base58Pubkey.optional().describe('Pin a specific Kamino LendingMarket. Without this, the reserve with the largest available_amount across all markets wins; the alternates are returned in the response.'),
+    leafIndex: z.number().int().nonnegative().optional().describe('Optional Merkle leaf index of the specific note to spend. Omit to auto-pick (exact-amount match → most-recent fallback).'),
   })
   .strict();
 
 export const privateRedeemInput = z
   .object({
-    leafIndex: z.number().int().nonnegative().optional().describe('Optional Merkle leaf index of the specific kUSDC voucher note to burn. Omit to use the most-recent. Each prior `private_lend` mints a kUSDC voucher commitment of value == lend amount; redeem burns one and unlocks the deposited USDC plus accrued interest from the per-user obligation.'),
+    mint: Base58Pubkey.optional().describe('Underlying mint of the position to redeem. Default USDC mainnet. Must match the mint that was lent.'),
+    market: Base58Pubkey.optional().describe('Pin a specific Kamino LendingMarket (matching the one used at lend time). Without this, the deepest reserve for the mint is used.'),
+    leafIndex: z.number().int().nonnegative().optional().describe('Optional Merkle leaf index of the specific voucher note to burn. Omit to use the most-recent.'),
   })
   .strict();
 

--- a/packages/mcp-server/src/tools/private_lend.ts
+++ b/packages/mcp-server/src/tools/private_lend.ts
@@ -1,19 +1,18 @@
 /**
- * private_lend — atomic private deposit into Kamino V2 USDC reserve.
+ * private_lend — atomic private deposit into a Kamino V2 reserve.
  *
- * Spends a shielded USDC note + deposits into Kamino + mints a kUSDC
- * voucher commitment. Each viewing key gets its own Kamino Obligation
- * (PRD-33 per-user obligation, derived from owner_pda). Mainnet only.
+ * Caller picks a mint (default USDC). The reserve is discovered on-chain:
+ * if multiple Kamino markets list that mint, the deepest by available
+ * supply wins, and alternates are returned in the response so the agent
+ * can switch markets next time. Pass `market` to pin a specific one.
  *
- * One-time setup performed automatically on first call:
- *   - Pre-fund adapter authority (~0.5 SOL) for Kamino UserMetadata +
- *     Obligation rent
- *   - Create owner_pda's USDC ATA (Kamino enforces token::authority ==
- *     obligationOwner on deposit)
- *   - Create / extend the persisted Address Lookup Table to fit all
- *     account refs in the 1232-byte tx cap
+ * Each viewing key gets its own Kamino Obligation per (mint, market)
+ * tuple. Mainnet only.
  *
- * Subsequent calls reuse all of the above.
+ * Auto-setup (cached per (mint, market) tuple):
+ *   - Pre-fund adapter authority for Kamino UserMetadata + Obligation rent
+ *   - Create owner_pda's <mint> ATA (Kamino requires token::authority == obligationOwner)
+ *   - Create / extend the persisted Address Lookup Table for the (market, reserve) tuple
  */
 
 import * as fs from 'node:fs';
@@ -24,13 +23,14 @@ import { createRpc } from '@lightprotocol/stateless.js';
 import {
   poolConfigPda, adapterRegistryPda, treeStatePda,
   tokenConfigPda, vaultPda, derivePendingInputsPda,
+  pickBestKaminoReserveByMint, findAllKaminoReservesByMint,
 } from '@b402ai/solana';
 import { leToFrReduced, type SpendableNote } from '@b402ai/solana-shared';
 
 import type { B402Context } from '../context.js';
 import type { PrivateLendInput } from '../schemas.js';
 import {
-  POOL, KAMINO_ADAPTER, RESERVE, USDC,
+  POOL, KAMINO_ADAPTER, USDC,
   parseReserve, deriveAllPerUser, ensureAlt, ensurePerUserSetup,
   ensureAdapterScratchAtas, adapterAuthorityPda,
   buildDepositPayload, buildAdapterIxData, buildDepositRemainingAccounts,
@@ -49,8 +49,13 @@ export async function handlePrivateLend(
 ): Promise<{
   signature: string;
   voucherDepositId: string;
+  market: string;
+  marketAlternates?: { market: string; reserve: string; availableAmount: string }[];
+  reserve: string;
+  symbol: string;
   obligationPda: string;
   ownerPda: string;
+  inMint: string;
   inAmount: string;
   outVaultDelta: string;
   setupTxs: string[];
@@ -59,31 +64,29 @@ export async function handlePrivateLend(
     throw new Error(`private_lend is mainnet-only (current cluster: ${ctx.cluster}). Kamino reserves don't exist on devnet/localnet.`);
   }
 
-  // ready() lazily inits the wallet + provers — must run before any
-  // ctx.b402.wallet access (b402.wallet getter throws otherwise).
   await ctx.b402.ready();
 
   const conn = new Connection(ctx.rpcUrl, 'confirmed');
   const admin = loadKeypair();
-  const inMint = USDC;
+  const inMint = input.mint ? new PublicKey(input.mint) : USDC;
   const lendAmount = BigInt(input.amount);
 
-  // SDK 0.0.20 routes commit_inputs through the hosted relayer's
-  // /relay/pool-ix endpoint when configured, so the user wallet stays
-  // off-chain. No monkey-patch needed; just call privateLend below.
-
-  // 1. Read + parse the Kamino USDC reserve.
-  const reserveAcct = await conn.getAccountInfo(RESERVE);
-  if (!reserveAcct) throw new Error(`Kamino USDC reserve ${RESERVE.toBase58()} not on chain`);
-  const reserve = parseReserve(reserveAcct.data);
-  if (!reserve.liquidityMint.equals(USDC)) {
-    throw new Error(`reserve liquidity mint ${reserve.liquidityMint.toBase58()} != USDC`);
+  // 1. Discover the Kamino reserve for this mint. If `market` is pinned,
+  //    only consider that market; otherwise scan all markets and pick
+  //    the deepest by available_amount.
+  const marketFilter = input.market ? { market: new PublicKey(input.market) } : {};
+  const picked = await pickBestKaminoReserveByMint(conn, inMint, marketFilter);
+  if (!picked) {
+    throw new Error(`no Kamino reserve found for mint ${inMint.toBase58()}${input.market ? ` in market ${input.market}` : ''}`);
   }
-  const outMint = reserve.collateralMint; // kUSDC
+  const reserveAddr = picked.best.address;
+  const market = picked.best.market;
+  const reserve = parseReserve(picked.best.data, market);
+  const outMint = reserve.collateralMint; // collateral mint (e.g. kUSDC, kSOL)
 
-  // 2. Derive per-user accounts from the SDK's spending pubkey.
+  // 2. Derive per-user accounts.
   const spendingPub = ctx.b402.wallet.spendingPub;
-  const perUser = deriveAllPerUser(spendingPub, reserve);
+  const perUser = deriveAllPerUser(spendingPub, reserve, market);
   const adapterAuthority = adapterAuthorityPda();
 
   const setupTxs: string[] = [];
@@ -100,10 +103,11 @@ export async function handlePrivateLend(
   if (setup.adapterFunded) setupTxs.push('adapter-funded');
   if (setup.ataCreated) setupTxs.push('owner-ata-created');
 
-  // 5. ALT (lazily extended).
+
+  // 5. ALT (lazily extended, persisted per (market, mint) tuple).
   const [pendingInputsPda] = derivePendingInputsPda(POOL, perUser.ownerPda.toBuffer());
   const altPubkey = await ensureAlt({
-    conn, admin, reserve, perUser, pendingInputsPda,
+    conn, admin, market, reserveAddr, reserve, perUser, pendingInputsPda,
     adapterAuthority, adapterInTa, adapterOutTa, outMint,
     poolHelpers: { poolConfigPda, adapterRegistryPda, treeStatePda, tokenConfigPda, vaultPda },
   });
@@ -143,9 +147,9 @@ export async function handlePrivateLend(
   const actualLendAmount = note.value;
 
   // 7. Build the adapter ix + remaining_accounts.
-  const actionPayload = buildDepositPayload(RESERVE, actualLendAmount);
+  const actionPayload = buildDepositPayload(reserveAddr, actualLendAmount);
   const adapterIxData = buildAdapterIxData(actualLendAmount, 0n, actionPayload);
-  const remainingAccounts = buildDepositRemainingAccounts({ reserve, perUser });
+  const remainingAccounts = buildDepositRemainingAccounts({ market, reserveAddr, reserve, perUser });
 
   // 8. Pool's kUSDC vault delta (informational — should be 0 for stateful adapter).
   const outVaultPda = vaultPda(POOL, outMint);
@@ -176,11 +180,25 @@ export async function handlePrivateLend(
   const postInfo = await conn.getAccountInfo(outVaultPda);
   const postKUsdc = postInfo ? BigInt(postInfo.data.readBigUInt64LE(64)) : 0n;
 
+  // Surface the runner-up markets so the caller can switch next time
+  // without re-discovering. Top 5 only — full list is available via
+  // list_kamino_reserves.
+  const marketAlternates = picked.alternates.slice(0, 5).map((a) => ({
+    market: a.market.toBase58(),
+    reserve: a.address.toBase58(),
+    availableAmount: a.availableAmount.toString(),
+  }));
+
   return {
     signature: lendRes.signature,
     voucherDepositId: lendRes.outNote.commitment.toString(16).padStart(64, '0').slice(0, 16),
+    market: market.toBase58(),
+    ...(marketAlternates.length > 0 ? { marketAlternates } : {}),
+    reserve: reserveAddr.toBase58(),
+    symbol: picked.best.symbol,
     obligationPda: perUser.obligation.toBase58(),
     ownerPda: perUser.ownerPda.toBase58(),
+    inMint: inMint.toBase58(),
     inAmount: actualLendAmount.toString(),
     outVaultDelta: (postKUsdc - preKUsdc).toString(),
     setupTxs,

--- a/packages/mcp-server/src/tools/private_redeem.ts
+++ b/packages/mcp-server/src/tools/private_redeem.ts
@@ -25,11 +25,12 @@ import { leToFrReduced, type SpendableNote } from '@b402ai/solana-shared';
 import type { B402Context } from '../context.js';
 import type { PrivateRedeemInput } from '../schemas.js';
 import {
-  POOL, KAMINO_ADAPTER, RESERVE, USDC,
+  POOL, KAMINO_ADAPTER, USDC,
   parseReserve, deriveAllPerUser, ensureAlt, ensurePerUserSetup,
   ensureAdapterScratchAtas, adapterAuthorityPda,
   buildWithdrawPayload, buildAdapterIxData, buildWithdrawRemainingAccounts,
 } from '../kamino-helpers.js';
+import { pickBestKaminoReserveByMint } from '@b402ai/solana';
 
 function loadKeypair(): Keypair {
   const p = path.resolve(
@@ -56,20 +57,22 @@ export async function handlePrivateRedeem(
 
   const conn = new Connection(ctx.rpcUrl, 'confirmed');
   const admin = loadKeypair();
-  const inMint = USDC;
+  const inMint = input.mint ? new PublicKey(input.mint) : USDC;
 
-  // SDK 0.0.20 routes commit_inputs through hosted relayer's
-  // /relay/pool-ix endpoint — user wallet stays off-chain.
-
-  // 1. Read + parse Kamino reserve.
-  const reserveAcct = await conn.getAccountInfo(RESERVE);
-  if (!reserveAcct) throw new Error(`Kamino USDC reserve ${RESERVE.toBase58()} not on chain`);
-  const reserve = parseReserve(reserveAcct.data);
-  const outMint = reserve.collateralMint; // kUSDC (the input for redeem)
+  // 1. Discover the (market, reserve) tuple — must match what was used at lend.
+  const marketFilter = input.market ? { market: new PublicKey(input.market) } : {};
+  const picked = await pickBestKaminoReserveByMint(conn, inMint, marketFilter);
+  if (!picked) {
+    throw new Error(`no Kamino reserve found for mint ${inMint.toBase58()}${input.market ? ` in market ${input.market}` : ''}`);
+  }
+  const reserveAddr = picked.best.address;
+  const market = picked.best.market;
+  const reserve = parseReserve(picked.best.data, market);
+  const outMint = reserve.collateralMint; // collateral mint (input for redeem — voucher being burned)
 
   // 2. Per-user accounts.
   const spendingPub = ctx.b402.wallet.spendingPub;
-  const perUser = deriveAllPerUser(spendingPub, reserve);
+  const perUser = deriveAllPerUser(spendingPub, reserve, market);
   const adapterAuthority = adapterAuthorityPda();
 
   // 3. Reverse adapter scratch ATAs: adapter_in_ta = kUSDC, adapter_out_ta = USDC.
@@ -100,10 +103,10 @@ export async function handlePrivateRedeem(
     conn, admin, outMint /* kUSDC */, relayerPubkey, true,
   );
 
-  // 6. ALT (extends with per-user PDAs lazily).
+  // 6. ALT (extends with per-user PDAs lazily, persisted per (market, mint)).
   const [pendingInputsPda] = derivePendingInputsPda(POOL, perUser.ownerPda.toBuffer());
   const altPubkey = await ensureAlt({
-    conn, admin, reserve, perUser, pendingInputsPda,
+    conn, admin, market, reserveAddr, reserve, perUser, pendingInputsPda,
     adapterAuthority,
     adapterInTa: wAdapterInTa, adapterOutTa: wAdapterOutTa,
     outMint: inMint, // for ALT purposes, want USDC + kUSDC token configs both included
@@ -135,9 +138,9 @@ export async function handlePrivateRedeem(
   const ktIn = redeemNote.value;
 
   // 8. Build adapter ix + ra_withdraw_per_user.
-  const actionPayload = buildWithdrawPayload(RESERVE, ktIn);
+  const actionPayload = buildWithdrawPayload(reserveAddr, ktIn);
   const adapterIxData = buildAdapterIxData(ktIn, 0n, actionPayload);
-  const remainingAccounts = buildWithdrawRemainingAccounts({ reserve, perUser });
+  const remainingAccounts = buildWithdrawRemainingAccounts({ market, reserveAddr, reserve, perUser });
 
   // 9. Pool's USDC vault delta — actual USDC redeemed.
   const usdcVaultPda = vaultPda(POOL, inMint);

--- a/packages/mcp-server/src/tools/private_redeem.ts
+++ b/packages/mcp-server/src/tools/private_redeem.ts
@@ -13,8 +13,11 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { Connection, Keypair, PublicKey } from '@solana/web3.js';
-import { getOrCreateAssociatedTokenAccount } from '@solana/spl-token';
+import { Connection, Keypair, PublicKey, Transaction } from '@solana/web3.js';
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAssociatedTokenAddressSync,
+} from '@solana/spl-token';
 import { createRpc } from '@lightprotocol/stateless.js';
 import {
   poolConfigPda, adapterRegistryPda, treeStatePda,
@@ -99,9 +102,33 @@ export async function handlePrivateRedeem(
   const relayerPubkey = sdkInternal._relayerHttp?.client.pubkey
     ?? sdkInternal.relayer?.publicKey
     ?? admin.publicKey;
-  await getOrCreateAssociatedTokenAccount(
-    conn, admin, outMint /* kUSDC */, relayerPubkey, true,
-  );
+  // Idempotent ATA create — only sends a tx if missing. Avoids
+  // getOrCreateAssociatedTokenAccount's WS-based confirm.
+  const relayerVoucherAta = getAssociatedTokenAddressSync(outMint, relayerPubkey, true);
+  const existing = await conn.getAccountInfo(relayerVoucherAta);
+  if (!existing) {
+    const tx = new Transaction().add(
+      createAssociatedTokenAccountIdempotentInstruction(
+        admin.publicKey, relayerVoucherAta, relayerPubkey, outMint,
+      ),
+    );
+    const bh = await conn.getLatestBlockhash('confirmed');
+    tx.recentBlockhash = bh.blockhash;
+    tx.feePayer = admin.publicKey;
+    tx.sign(admin);
+    const sig = await conn.sendRawTransaction(tx.serialize(), { skipPreflight: false, preflightCommitment: 'confirmed' });
+    // Poll for confirm without WS subs.
+    const start = Date.now();
+    let interval = 2000;
+    while (Date.now() - start < 90_000) {
+      const r = await conn.getSignatureStatuses([sig], { searchTransactionHistory: false });
+      const s = r.value[0];
+      if (s?.confirmationStatus === 'confirmed' || s?.confirmationStatus === 'finalized') break;
+      if (s?.err) throw new Error(`relayer voucher ATA tx failed: ${JSON.stringify(s.err)}`);
+      await new Promise((r) => setTimeout(r, interval));
+      interval = Math.min(interval * 1.2, 5000);
+    }
+  }
 
   // 6. ALT (extends with per-user PDAs lazily, persisted per (market, mint)).
   const [pendingInputsPda] = derivePendingInputsPda(POOL, perUser.ownerPda.toBuffer());

--- a/packages/relayer/src/index.ts
+++ b/packages/relayer/src/index.ts
@@ -46,7 +46,16 @@ export async function buildServer() {
     trustProxy: true,
   });
 
-  const connection = new Connection(cfg.rpcUrl, 'confirmed');
+  // confirmTransactionInitialTimeout = how long web3.js waits for the
+  // first confirmation before declaring the tx unconfirmed. The default
+  // (~30s) is too tight for current mainnet — Kamino lend's commit_inputs
+  // sub-tx can take 25-40s under typical Helius load and the strict 30s
+  // races the network. 90s gives enough buffer that the relayer surfaces
+  // the actual signature back to the SDK before timing out.
+  const connection = new Connection(cfg.rpcUrl, {
+    commitment: 'confirmed',
+    confirmTransactionInitialTimeout: 90_000,
+  });
   const auth = new Authenticator(cfg);
   const submitter = new RpcSubmitter({
     connection,

--- a/packages/relayer/src/submit.ts
+++ b/packages/relayer/src/submit.ts
@@ -186,13 +186,17 @@ export class RpcSubmitter implements Submitter {
     } catch (e) {
       throw Errors.rpcFailure(`sendRawTransaction failed: ${(e as Error).message}`);
     }
-    const conf = await connection.confirmTransaction(sig, 'confirmed');
-    if (conf.value.err) {
-      throw Errors.rpcFailure(`tx failed on-chain: ${JSON.stringify(conf.value.err)}`, { signature: sig });
+    // Use HTTP-poll confirmation instead of confirmTransaction's WS path.
+    // WS subscriptions get rate-limited hard on Helius's free tier (we
+    // observed 19+ ws 429s per attempt under load). Polling is a single
+    // getSignatureStatuses HTTP call per check — way friendlier.
+    const conf = await pollForConfirmation(connection, sig, 90_000);
+    if (conf.err) {
+      throw Errors.rpcFailure(`tx failed on-chain: ${JSON.stringify(conf.err)}`, { signature: sig });
     }
     return {
       signature: sig,
-      slot: conf.context.slot,
+      slot: conf.slot,
       confirmedAt: new Date().toISOString(),
     };
   }
@@ -224,16 +228,57 @@ export class RpcSubmitter implements Submitter {
     // polled via getSignatureStatuses against the embedded tx — here we
     // recompute the signature locally from the wire bytes.
     const sig = recoverFirstSignature(wire);
-    const confirmed = await this.deps.connection.confirmTransaction(sig, 'confirmed');
-    if (confirmed.value.err) {
-      throw Errors.rpcFailure(`tx failed on-chain (jito): ${JSON.stringify(confirmed.value.err)}`, { signature: sig });
+    const confirmed = await pollForConfirmation(this.deps.connection, sig, 90_000);
+    if (confirmed.err) {
+      throw Errors.rpcFailure(`tx failed on-chain (jito): ${JSON.stringify(confirmed.err)}`, { signature: sig });
     }
     return {
       signature: sig,
-      slot: confirmed.context.slot,
+      slot: confirmed.slot,
       confirmedAt: new Date().toISOString(),
     };
   }
+}
+
+/**
+ * HTTP-poll for a tx signature reaching `confirmed` status. Replaces
+ * `connection.confirmTransaction` for relayer use because the latter
+ * uses a WebSocket subscription that gets rate-limited on shared RPC
+ * endpoints (Helius free tier returns 429 on the ws upgrade after a
+ * few open subs, leaving the SDK never seeing the confirmation event
+ * even when the tx Finalized 60s ago).
+ *
+ * Strategy: getSignatureStatuses every `interval` ms with a gentle
+ * backoff up to 5s. One HTTP call per poll, no WS state held open.
+ *
+ * Note: `confirmed` is sufficient for our pool-ix flows — adapter CPIs
+ * land or revert atomically; once a tx is confirmed it won't reorg out
+ * in practice (Solana finality after 31 confirmations ~ 13s).
+ */
+async function pollForConfirmation(
+  connection: import('@solana/web3.js').Connection,
+  signature: string,
+  timeoutMs: number,
+): Promise<{ slot: number; err: unknown }> {
+  const start = Date.now();
+  let interval = 2000;
+  while (Date.now() - start < timeoutMs) {
+    const res = await connection.getSignatureStatuses([signature], { searchTransactionHistory: false });
+    const s = res.value[0];
+    if (s) {
+      if (s.err) return { slot: s.slot, err: s.err };
+      if (s.confirmationStatus === 'confirmed' || s.confirmationStatus === 'finalized') {
+        return { slot: s.slot, err: null };
+      }
+    }
+    await new Promise((r) => setTimeout(r, interval));
+    // Gentle backoff: 2s → 2.4 → 2.88 → 3.46 → 4.15 → 4.99 → 5 (capped).
+    interval = Math.min(interval * 1.2, 5000);
+  }
+  throw Errors.rpcFailure(
+    `tx not confirmed within ${timeoutMs / 1000}s — check signature on Solscan, may have landed but poll timed out`,
+    { signature },
+  );
 }
 
 /** Recover the first signature from a serialised v0 tx — the fee-payer sig.

--- a/packages/relayer/test/submit.test.ts
+++ b/packages/relayer/test/submit.test.ts
@@ -43,6 +43,18 @@ function fakeConnection(overrides: Partial<{
       value: { err: confirmErr },
       context: { slot },
     })),
+    // pollForConfirmation in submit.ts uses getSignatureStatuses now
+    // (replaces the WS-based confirmTransaction). Fake confirms on first
+    // poll so tests don't sleep through the backoff loop.
+    getSignatureStatuses: vi.fn(async (_sigs: string[]) => ({
+      value: [{
+        slot,
+        confirmations: 1,
+        err: confirmErr,
+        confirmationStatus: 'confirmed',
+      }],
+      context: { slot },
+    })),
     getSlot: vi.fn(async () => slot),
     getBalance: vi.fn(async () => 1_000_000_000),
   } as unknown as Connection;

--- a/packages/sdk/src/b402.ts
+++ b/packages/sdk/src/b402.ts
@@ -986,12 +986,41 @@ export class B402Solana {
     // on the heavyweight tx, lifting the v0-tx 1232 B ceiling that
     // today blocks per-user adapters at scale.
     if (req.pendingInputsMode) {
-      const { buildCommitInputsIx } = await import('./commit-inputs.js');
+      const { buildCommitInputsIx, derivePendingInputsPda } = await import('./commit-inputs.js');
       const spendingPubLe = bigintToLe32(this._wallet!.spendingPub);
+      const inputs = proof.publicInputsLeBytes.map((b) => new Uint8Array(b));
+
+      // Idempotency: if a prior attempt already wrote the same inputs to
+      // the per-user pending_inputs PDA, skip submitting a fresh commit
+      // tx. Saves ~$0.0009 + the round-trip latency, and avoids a redundant
+      // tx racing the previous one through Helius (where ws confirms can
+      // lag the chain by 30+ s under load).
+      // PDA layout: 8 (anchor disc) + 1 (version) + 32 × N (inputs) + ...
+      const [pendingPda] = derivePendingInputsPda(
+        new PublicKey(this.programIds.b402Pool),
+        spendingPubLe,
+      );
+      const existing = await this.connection.getAccountInfo(pendingPda, 'confirmed');
+      const expectedBytes = new Uint8Array(inputs.length * 32);
+      for (let i = 0; i < inputs.length; i++) expectedBytes.set(inputs[i], i * 32);
+      const PENDING_INPUTS_HEADER = 8 + 1; // disc + version byte
+      const alreadyCommitted =
+        existing &&
+        existing.data.length >= PENDING_INPUTS_HEADER + expectedBytes.length &&
+        existing.data[8] === 1 && // version flag — pool sets to 1 on commit
+        Buffer.from(existing.data).subarray(
+          PENDING_INPUTS_HEADER,
+          PENDING_INPUTS_HEADER + expectedBytes.length,
+        ).equals(Buffer.from(expectedBytes));
+
+      if (alreadyCommitted) {
+        // Skip the commit tx entirely; adapt_execute_v2 below reads the
+        // PDA we already wrote.
+      } else {
       const commitIx = buildCommitInputsIx({
         poolProgramId: new PublicKey(this.programIds.b402Pool),
         spendingPubLe,
-        inputs: proof.publicInputsLeBytes.map((b) => new Uint8Array(b)),
+        inputs,
         relayer: relayerPubkey,
       });
       // Two paths:
@@ -1026,6 +1055,7 @@ export class B402Solana {
           'confirmed',
         );
       }
+      } // end else (alreadyCommitted check)
     }
 
     // 7. Adapter ix data: default mock-adapter shape (discriminator + amount +

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -56,6 +56,29 @@ export {
   type KaminoPerUserAccounts,
 } from './kamino.js';
 
+// On-chain reserve discovery (no static reserve map).
+export {
+  KLEND_PROGRAM_ID,
+  RESERVE_DISCRIMINATOR,
+  LENDING_MARKET_DISCRIMINATOR,
+  RESERVE_ACCOUNT_SIZE,
+  LENDING_MARKET_ACCOUNT_SIZE,
+  RESERVE_LENDING_MARKET_OFFSET,
+  RESERVE_FARM_COLLATERAL_OFFSET,
+  RESERVE_LIQUIDITY_MINT_OFFSET,
+  RESERVE_TOKEN_INFO_NAME_OFFSET,
+  RESERVE_AVAILABLE_AMOUNT_OFFSET,
+  RESERVE_BORROWED_AMOUNT_SF_OFFSET,
+  discoverKaminoMarkets,
+  discoverKaminoReserves,
+  findKaminoReserveByMint,
+  findAllKaminoReservesByMint,
+  pickBestKaminoReserveByMint,
+  type DiscoveredReserve,
+  type DiscoveredMarket,
+  type DiscoverReservesOptions,
+} from './kamino-discover.js';
+
 /** Solana hard tx-size cap. */
 export const MAX_TX_SIZE = 1232;
 /** Soft ceiling for adapter action_payload. Pool recomputes keccak over it. */

--- a/packages/sdk/src/kamino-discover.ts
+++ b/packages/sdk/src/kamino-discover.ts
@@ -1,0 +1,234 @@
+/**
+ * On-chain discovery for Kamino markets + reserves.
+ *
+ * Markets and reserves are NOT derivable from a static seed/mint tuple —
+ * Kamino allocates each Reserve account at init time and stores the
+ * `lending_market` reference inside the Reserve struct (offset 32). The
+ * only way to enumerate them is `getProgramAccounts(KLEND)` filtered by
+ * the Reserve anchor discriminator.
+ *
+ * What this module gives you:
+ *   - `discoverKaminoMarkets(connection)` → every LendingMarket on chain
+ *   - `discoverKaminoReserves(connection, opts?)` → every Reserve, with
+ *     parsed market + liquidityMint + collateral mint
+ *   - `findKaminoReserveByMint(connection, mint, opts?)` → first reserve
+ *     whose liquidityMint matches; optionally constrained to a market
+ *
+ * Caching: getProgramAccounts is heavy on shared mainnet RPC. Caller is
+ * responsible for caching results (typical lifetime: ~minutes — markets
+ * and reserves change rarely).
+ *
+ * What this module does NOT do:
+ *   - APY / utilization / interest-model parsing (separate `kamino-apy`
+ *     module would handle that, reading interestRate fields from each
+ *     Reserve and applying Kamino's curve)
+ *   - Volume / TVL ranking (off-chain analytics, not in this lib)
+ *   - Picking the "best" market for a mint — caller's policy
+ */
+
+import { Connection, PublicKey } from '@solana/web3.js';
+
+/** KLend program id (mainnet). Kamino's lending core program. */
+export const KLEND_PROGRAM_ID = new PublicKey('KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD');
+
+/** Anchor disc for KLend `Reserve` accounts. */
+export const RESERVE_DISCRIMINATOR = Uint8Array.from([
+  43, 242, 204, 202, 26, 247, 59, 127,
+]);
+
+/** Anchor disc for KLend `LendingMarket` accounts. */
+export const LENDING_MARKET_DISCRIMINATOR = Uint8Array.from([
+  246, 114, 50, 98, 72, 157, 28, 120,
+]);
+
+/** Reserve account size (verified across mainnet reserves). */
+export const RESERVE_ACCOUNT_SIZE = 8624;
+
+/** LendingMarket account size (verified mainnet). */
+export const LENDING_MARKET_ACCOUNT_SIZE = 4664;
+
+/** Reserve struct field offsets (verified across multiple reserves). */
+export const RESERVE_LENDING_MARKET_OFFSET = 32;
+export const RESERVE_FARM_COLLATERAL_OFFSET = 64;
+export const RESERVE_LIQUIDITY_MINT_OFFSET = 128;
+/** TokenInfo.name (32-byte zero-padded ASCII symbol like "USDC\0…"). */
+export const RESERVE_TOKEN_INFO_NAME_OFFSET = 5032;
+
+/** Reserve.liquidity.available_amount (u64) — cash in the supply vault.
+ *  This is liquid supply only; borrowed funds are not here. */
+export const RESERVE_AVAILABLE_AMOUNT_OFFSET = 224;
+
+/** Reserve.liquidity.borrowed_amount_sf (u128, Kamino's "scaled fraction"
+ *  = raw_amount << 60). Add to available_amount for total supply. */
+export const RESERVE_BORROWED_AMOUNT_SF_OFFSET = 232;
+const KAMINO_FRACTION_SHIFT = 60n;
+
+/** Read a 32-byte symbol field, trim trailing zeros. */
+function readSymbol(data: Buffer): string {
+  const buf = data.subarray(RESERVE_TOKEN_INFO_NAME_OFFSET, RESERVE_TOKEN_INFO_NAME_OFFSET + 32);
+  const end = buf.indexOf(0);
+  return buf.subarray(0, end < 0 ? 32 : end).toString('utf8');
+}
+
+export interface DiscoveredReserve {
+  /** Reserve PDA (account address). */
+  address: PublicKey;
+  /** LendingMarket the reserve belongs to. */
+  market: PublicKey;
+  /** Liquidity mint (the token deposited). */
+  liquidityMint: PublicKey;
+  /** Symbol from on-chain TokenInfo.name (e.g. "USDC", "SOL"). */
+  symbol: string;
+  /** Reserve's farm-collateral pubkey, or PublicKey.default if no farm. */
+  farmCollateral: PublicKey;
+  /** Raw u64 of `liquidity.available_amount` — cash in supply vault. */
+  availableAmount: bigint;
+  /** Total supply in raw units (available + borrowed). The right depth
+   *  metric for ranking — established markets have most of their funds
+   *  borrowed, so available_amount alone underestimates them by 100x or
+   *  more. */
+  totalSupply: bigint;
+  /** Raw account bytes — caller can run a richer parser (oracles, etc.). */
+  data: Buffer;
+}
+
+export interface DiscoveredMarket {
+  /** LendingMarket account address. */
+  address: PublicKey;
+  /** Raw account bytes. */
+  data: Buffer;
+}
+
+/** All LendingMarket accounts owned by KLEND on the connected cluster.
+ *  ~10-30 results on mainnet, sub-second on Helius / Triton. */
+export async function discoverKaminoMarkets(
+  connection: Connection,
+): Promise<DiscoveredMarket[]> {
+  const accounts = await connection.getProgramAccounts(KLEND_PROGRAM_ID, {
+    commitment: 'confirmed',
+    filters: [
+      { dataSize: LENDING_MARKET_ACCOUNT_SIZE },
+      { memcmp: { offset: 0, bytes: bs58Encode(LENDING_MARKET_DISCRIMINATOR) } },
+    ],
+  });
+  return accounts.map((a) => ({
+    address: a.pubkey,
+    data: Buffer.from(a.account.data),
+  }));
+}
+
+export interface DiscoverReservesOptions {
+  /** Restrict to a specific market (e.g. "Main"). */
+  market?: PublicKey;
+}
+
+/** Every Reserve account owned by KLEND, parsed for the fields we need
+ *  to route a deposit/withdraw without re-reading the chain. */
+export async function discoverKaminoReserves(
+  connection: Connection,
+  options: DiscoverReservesOptions = {},
+): Promise<DiscoveredReserve[]> {
+  const filters: Parameters<Connection['getProgramAccounts']>[1] = {
+    commitment: 'confirmed',
+    filters: [
+      { dataSize: RESERVE_ACCOUNT_SIZE },
+      { memcmp: { offset: 0, bytes: bs58Encode(RESERVE_DISCRIMINATOR) } },
+    ],
+  };
+  if (options.market) {
+    filters.filters!.push({
+      memcmp: { offset: RESERVE_LENDING_MARKET_OFFSET, bytes: options.market.toBase58() },
+    });
+  }
+  const accounts = await connection.getProgramAccounts(KLEND_PROGRAM_ID, filters);
+
+  return accounts.map((a) => {
+    const data = Buffer.from(a.account.data);
+    const available = data.readBigUInt64LE(RESERVE_AVAILABLE_AMOUNT_OFFSET);
+    // borrowed_amount_sf is u128 little-endian at offset 232. Read as two
+    // u64s and combine. Kamino's scaled-fraction format means
+    // raw_borrowed = sf >> 60.
+    const borrowedLo = data.readBigUInt64LE(RESERVE_BORROWED_AMOUNT_SF_OFFSET);
+    const borrowedHi = data.readBigUInt64LE(RESERVE_BORROWED_AMOUNT_SF_OFFSET + 8);
+    const borrowedSf = borrowedLo | (borrowedHi << 64n);
+    const borrowedRaw = borrowedSf >> KAMINO_FRACTION_SHIFT;
+    return {
+      address: a.pubkey,
+      market: new PublicKey(data.subarray(RESERVE_LENDING_MARKET_OFFSET, RESERVE_LENDING_MARKET_OFFSET + 32)),
+      liquidityMint: new PublicKey(data.subarray(RESERVE_LIQUIDITY_MINT_OFFSET, RESERVE_LIQUIDITY_MINT_OFFSET + 32)),
+      symbol: readSymbol(data),
+      farmCollateral: new PublicKey(data.subarray(RESERVE_FARM_COLLATERAL_OFFSET, RESERVE_FARM_COLLATERAL_OFFSET + 32)),
+      availableAmount: available,
+      totalSupply: available + borrowedRaw,
+      data,
+    };
+  });
+}
+
+/** Pick the deepest reserve for a mint, returning the choice + the
+ *  alternates (sorted desc by availableAmount). Used by
+ *  private_lend / private_redeem to default to the largest-liquidity
+ *  match while exposing the runner-ups in the response so the caller
+ *  can switch markets next time.
+ *
+ *  Returns null if no reserve exists for the mint. */
+export async function pickBestKaminoReserveByMint(
+  connection: Connection,
+  mint: PublicKey,
+  options: DiscoverReservesOptions = {},
+): Promise<{ best: DiscoveredReserve; alternates: DiscoveredReserve[] } | null> {
+  const matches = await findAllKaminoReservesByMint(connection, mint, options);
+  if (matches.length === 0) return null;
+  // Sort by total supply (available + borrowed). Established markets have
+  // most of their funds borrowed out, so available_amount alone would
+  // unfairly favor low-utilization isolated markets.
+  matches.sort((a, b) => (a.totalSupply > b.totalSupply ? -1 : a.totalSupply < b.totalSupply ? 1 : 0));
+  return { best: matches[0], alternates: matches.slice(1) };
+}
+
+/** Find the first reserve (across all markets, or constrained to one)
+ *  whose liquidityMint == `mint`. Returns null if no match.
+ *
+ *  When the mint is listed in multiple markets and the caller hasn't
+ *  passed `options.market`, this returns whichever Kamino enumerated
+ *  first — order isn't stable across RPC calls. Prefer
+ *  `findAllKaminoReservesByMint` and let the caller / agent pick. */
+export async function findKaminoReserveByMint(
+  connection: Connection,
+  mint: PublicKey,
+  options: DiscoverReservesOptions = {},
+): Promise<DiscoveredReserve | null> {
+  const matches = await findAllKaminoReservesByMint(connection, mint, options);
+  return matches[0] ?? null;
+}
+
+/** Every reserve whose liquidityMint == `mint`. Empty if unsupported.
+ *
+ *  Use this when the mint can appear in multiple markets (USDC, SOL,
+ *  JLP, etc.) and the caller wants to surface the full picker / let the
+ *  user choose by APY, market name, or other policy. */
+export async function findAllKaminoReservesByMint(
+  connection: Connection,
+  mint: PublicKey,
+  options: DiscoverReservesOptions = {},
+): Promise<DiscoveredReserve[]> {
+  const all = await discoverKaminoReserves(connection, options);
+  return all.filter((r) => r.liquidityMint.equals(mint));
+}
+
+// — minimal base58 encoder for the memcmp filter without dragging bs58 in —
+// stateless.js / @solana/web3.js already pull bs58 transitively, but keeping
+// this import-free avoids a cross-package version pin.
+function bs58Encode(bytes: Uint8Array): string {
+  const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+  let zeros = 0;
+  while (zeros < bytes.length && bytes[zeros] === 0) zeros++;
+  let n = 0n;
+  for (const b of bytes) n = (n << 8n) + BigInt(b);
+  let out = '';
+  while (n > 0n) {
+    out = ALPHABET[Number(n % 58n)] + out;
+    n /= 58n;
+  }
+  return '1'.repeat(zeros) + out;
+}

--- a/programs/b402-kamino-adapter/Cargo.toml
+++ b/programs/b402-kamino-adapter/Cargo.toml
@@ -14,6 +14,9 @@ no-idl = []
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []
+# Anchor 0.30 requires the idl-build feature on the program crate when
+# `anchor build` is run. Empty body — only enabled by the build pipeline.
+idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 # PRD-33 Phase 33.2: per-user Kamino obligation. When enabled, the action
 # payload's leading 32 B are interpreted as the user's viewing_pub_hash
 # (= bytes_le(outSpendingPub) from the Phase 9 adapt proof). The adapter

--- a/programs/b402-kamino-adapter/src/lib.rs
+++ b/programs/b402-kamino-adapter/src/lib.rs
@@ -429,14 +429,23 @@ pub mod b402_kamino_adapter {
                 require!(*act_in == in_amount, KaminoAdapterError::AmountMismatch);
                 #[cfg(feature = "per_user_obligation")]
                 {
+                    // Read liquidity_mint from the reserve account in
+                    // remaining_accounts[ra_deposit::RESERVE]. Required as a
+                    // PDA seed so each (viewing_key, mint) gets its own
+                    // independent Kamino obligation — preventing the
+                    // refresh_obligation walks-all-reserves problem and
+                    // making positions independently redeemable.
+                    let liquidity_mint =
+                        read_reserve_liquidity_mint(&ctx, ra_deposit::RESERVE)?;
                     let (expected_owner_pda, owner_bump) =
-                        derive_owner_pda(&crate::ID, &viewing_pub_hash);
+                        derive_owner_pda(&crate::ID, &viewing_pub_hash, &liquidity_mint);
                     handle_deposit_per_user(
                         &ctx,
                         *reserve,
                         *act_in,
                         *min_kt_out,
                         &viewing_pub_hash,
+                        liquidity_mint,
                         expected_owner_pda,
                         owner_bump,
                         bump,
@@ -453,14 +462,19 @@ pub mod b402_kamino_adapter {
                 require!(*kt_in == in_amount, KaminoAdapterError::AmountMismatch);
                 #[cfg(feature = "per_user_obligation")]
                 {
+                    // Same per-mint derivation as deposit. RA layout for
+                    // withdraw also has reserve at slot 0.
+                    let liquidity_mint =
+                        read_reserve_liquidity_mint(&ctx, ra_withdraw_per_user::WITHDRAW_RESERVE)?;
                     let (expected_owner_pda, owner_bump) =
-                        derive_owner_pda(&crate::ID, &viewing_pub_hash);
+                        derive_owner_pda(&crate::ID, &viewing_pub_hash, &liquidity_mint);
                     handle_withdraw_per_user(
                         &ctx,
                         *reserve,
                         *kt_in,
                         *min_underlying_out,
                         &viewing_pub_hash,
+                        liquidity_mint,
                         expected_owner_pda,
                         owner_bump,
                         bump,
@@ -1120,6 +1134,7 @@ fn handle_deposit_per_user<'info>(
     in_amount: u64,
     _min_kt_out: u64,
     viewing_pub_hash: &[u8; 32],
+    mint: Pubkey,
     expected_owner_pda: Pubkey,
     owner_bump: u8,
     auth_bump: u8,
@@ -1148,10 +1163,12 @@ fn handle_deposit_per_user<'info>(
     // post-CPI sweep). `owner_seeds` signs for `owner_pda` (Kamino-side
     // obligation owner). PRD-33 §3.3.
     let auth_seeds: &[&[u8]] = &[VERSION_PREFIX, SEED_ADAPTER, &[auth_bump]];
+    let mint_seed = mint.as_ref();
     let owner_seeds: &[&[u8]] = &[
         VERSION_PREFIX,
         SEED_ADAPTER_OWNER,
         viewing_pub_hash.as_ref(),
+        mint_seed,
         &[owner_bump],
     ];
     let signer_seeds: &[&[&[u8]]] = &[auth_seeds, owner_seeds];
@@ -1428,6 +1445,7 @@ fn handle_withdraw_per_user<'info>(
     kt_in: u64,
     _min_underlying_out: u64,
     viewing_pub_hash: &[u8; 32],
+    mint: Pubkey,
     expected_owner_pda: Pubkey,
     owner_bump: u8,
     auth_bump: u8,
@@ -1450,10 +1468,12 @@ fn handle_withdraw_per_user<'info>(
     let owner_key = owner_pda_info.key();
 
     let auth_seeds: &[&[u8]] = &[VERSION_PREFIX, SEED_ADAPTER, &[auth_bump]];
+    let mint_seed = mint.as_ref();
     let owner_seeds: &[&[u8]] = &[
         VERSION_PREFIX,
         SEED_ADAPTER_OWNER,
         viewing_pub_hash.as_ref(),
+        mint_seed,
         &[owner_bump],
     ];
     let signer_seeds: &[&[&[u8]]] = &[auth_seeds, owner_seeds];
@@ -1870,9 +1890,39 @@ pub enum KaminoAdapterError {
 /// own `program_id`) makes the same `viewing_pub_hash` resolve to a
 /// DIFFERENT `owner_pda` on Drift / Marginfi adapters — cross-protocol
 /// correlation by `owner_pda` alone is impossible.
-pub fn derive_owner_pda(adapter_program_id: &Pubkey, viewing_pub_hash: &[u8; 32]) -> (Pubkey, u8) {
+/// Read `liquidity.mint_pubkey` from a Kamino Reserve account at offset 128.
+/// Returns `KaminoCpiFailed` if the account is too short or the slot can't be
+/// parsed. The Reserve struct's mint offset is stable across reserves —
+/// verified empirically against USDC + SOL reserves on mainnet.
+fn read_reserve_liquidity_mint(
+    ctx: &Context<'_, '_, '_, '_, Execute<'_>>,
+    ra_index: usize,
+) -> Result<Pubkey> {
+    const LIQUIDITY_MINT_OFFSET: usize = 128;
+    let info = &ctx.remaining_accounts[ra_index];
+    let data = info.try_borrow_data().map_err(|_| KaminoAdapterError::KaminoCpiFailed)?;
+    require!(
+        data.len() >= LIQUIDITY_MINT_OFFSET + 32,
+        KaminoAdapterError::KaminoCpiFailed
+    );
+    let mut buf = [0u8; 32];
+    buf.copy_from_slice(&data[LIQUIDITY_MINT_OFFSET..LIQUIDITY_MINT_OFFSET + 32]);
+    Ok(Pubkey::new_from_array(buf))
+}
+
+/// Derive the per-(viewing_key, mint) `owner_pda`. Each lending position
+/// keyed by liquidity mint gets its own Kamino UserMetadata + Obligation,
+/// so positions across mints (USDC, SOL, JitoSOL, …) are structurally
+/// independent — no shared collateralization, no Klend's `RefreshObligation`
+/// having to walk every existing reserve when adding a new one. PRD-33 §3.3
+/// (extended).
+pub fn derive_owner_pda(
+    adapter_program_id: &Pubkey,
+    viewing_pub_hash: &[u8; 32],
+    mint: &Pubkey,
+) -> (Pubkey, u8) {
     Pubkey::find_program_address(
-        &[VERSION_PREFIX, SEED_ADAPTER_OWNER, viewing_pub_hash.as_ref()],
+        &[VERSION_PREFIX, SEED_ADAPTER_OWNER, viewing_pub_hash.as_ref(), mint.as_ref()],
         adapter_program_id,
     )
 }

--- a/programs/b402-kamino-adapter/tests/per_user_payload.rs
+++ b/programs/b402-kamino-adapter/tests/per_user_payload.rs
@@ -71,24 +71,33 @@ fn decode_per_user_payload_rejects_missing_inner_action() {
     );
 }
 
+/// Mainnet USDC for the per-mint PDA tests below — any 32-byte pubkey
+/// works, USDC is just a stable choice.
+const USDC_MINT_BYTES: [u8; 32] = [
+    198, 250, 122, 243, 190, 219, 173, 58, 61, 101, 243, 106, 171, 201, 116, 49,
+    177, 187, 228, 194, 210, 246, 224, 228, 124, 166, 2, 3, 69, 47, 93, 97,
+];
+
 #[test]
 fn derive_owner_pda_is_deterministic() {
     let h = fixed_hash(0x11);
-    let (a, b1) = derive_owner_pda(&ADAPTER_ID, &h);
-    let (a2, b2) = derive_owner_pda(&ADAPTER_ID, &h);
-    assert_eq!(a, a2, "same hash → same PDA");
-    assert_eq!(b1, b2, "same hash → same bump");
+    let mint = Pubkey::new_from_array(USDC_MINT_BYTES);
+    let (a, b1) = derive_owner_pda(&ADAPTER_ID, &h, &mint);
+    let (a2, b2) = derive_owner_pda(&ADAPTER_ID, &h, &mint);
+    assert_eq!(a, a2, "same hash + mint → same PDA");
+    assert_eq!(b1, b2, "same hash + mint → same bump");
 }
 
 #[test]
 fn three_distinct_users_get_three_distinct_owner_pdas() {
+    let mint = Pubkey::new_from_array(USDC_MINT_BYTES);
     let alice_hash = fixed_hash(0xA1);
     let bob_hash = fixed_hash(0xB2);
     let carol_hash = fixed_hash(0xC3);
 
-    let (alice_pda, _) = derive_owner_pda(&ADAPTER_ID, &alice_hash);
-    let (bob_pda, _) = derive_owner_pda(&ADAPTER_ID, &bob_hash);
-    let (carol_pda, _) = derive_owner_pda(&ADAPTER_ID, &carol_hash);
+    let (alice_pda, _) = derive_owner_pda(&ADAPTER_ID, &alice_hash, &mint);
+    let (bob_pda, _) = derive_owner_pda(&ADAPTER_ID, &bob_hash, &mint);
+    let (carol_pda, _) = derive_owner_pda(&ADAPTER_ID, &carol_hash, &mint);
 
     assert_ne!(alice_pda, bob_pda, "alice ≠ bob owner_pda");
     assert_ne!(bob_pda, carol_pda, "bob ≠ carol owner_pda");
@@ -96,27 +105,45 @@ fn three_distinct_users_get_three_distinct_owner_pdas() {
 }
 
 #[test]
+fn same_user_different_mints_get_different_pdas() {
+    // Per-(viewing_key, mint) derivation: a single user lending USDC and
+    // SOL must end up with TWO independent Kamino obligations. Without
+    // this, refresh_obligation has to walk both reserves on every op and
+    // positions can't be redeemed independently.
+    let h = fixed_hash(0x44);
+    let usdc_mint = Pubkey::new_from_array(USDC_MINT_BYTES);
+    let sol_mint = Pubkey::new_from_array([
+        6, 155, 136, 87, 254, 171, 129, 132, 251, 104, 127, 99, 70, 24, 192,
+        53, 218, 196, 57, 220, 26, 235, 59, 85, 152, 160, 240, 0, 0, 0, 0, 1,
+    ]);
+    let (usdc_pda, _) = derive_owner_pda(&ADAPTER_ID, &h, &usdc_mint);
+    let (sol_pda, _) = derive_owner_pda(&ADAPTER_ID, &h, &sol_mint);
+    assert_ne!(usdc_pda, sol_pda, "same user, different mint → distinct PDA");
+}
+
+#[test]
 fn owner_pda_changes_with_one_bit_flip() {
+    let mint = Pubkey::new_from_array(USDC_MINT_BYTES);
     let mut h = fixed_hash(0x22);
-    let (orig_pda, _) = derive_owner_pda(&ADAPTER_ID, &h);
+    let (orig_pda, _) = derive_owner_pda(&ADAPTER_ID, &h, &mint);
     // Flip a single bit in the viewing_pub_hash.
     h[0] ^= 0x01;
-    let (perturbed_pda, _) = derive_owner_pda(&ADAPTER_ID, &h);
+    let (perturbed_pda, _) = derive_owner_pda(&ADAPTER_ID, &h, &mint);
     assert_ne!(orig_pda, perturbed_pda);
 }
 
 #[test]
-fn owner_pda_seeds_match_prd_33_section_3_2() {
-    // PRD-33 §3.2 pins the seed list. If anyone reorders these seeds the
-    // SDK-derived owner_pda diverges from the on-chain derivation and every
-    // per-user deposit dies with `KaminoCpiFailed` (signer seeds wrong).
-    // Pinning the exact byte representation here makes that drift loud.
+fn owner_pda_seeds_match_extended_layout() {
+    // Pinned seed list: ["b402/v1", "adapter-owner", viewing_pub_hash, mint].
+    // SDK derivation must match byte-for-byte or every per-user deposit
+    // dies with KaminoCpiFailed (signer seeds wrong).
     let h = fixed_hash(0x33);
+    let mint = Pubkey::new_from_array(USDC_MINT_BYTES);
     let (expected_pda, expected_bump) = Pubkey::find_program_address(
-        &[b"b402/v1", b"adapter-owner", h.as_ref()],
+        &[b"b402/v1", b"adapter-owner", h.as_ref(), mint.as_ref()],
         &ADAPTER_ID,
     );
-    let (actual_pda, actual_bump) = derive_owner_pda(&ADAPTER_ID, &h);
+    let (actual_pda, actual_bump) = derive_owner_pda(&ADAPTER_ID, &h, &mint);
     assert_eq!(actual_pda, expected_pda);
     assert_eq!(actual_bump, expected_bump);
 }


### PR DESCRIPTION
## Summary

Three connected changes that unblock private lending on Kamino at scale.

### 1. On-chain reserve discovery (zero hardcoding)
- `discoverKaminoMarkets(connection)` → all 182 LendingMarkets on mainnet via getProgramAccounts
- `discoverKaminoReserves(connection, {market?})` → all reserves, parsed for market + mint + symbol + farm + availableAmount + totalSupply
- `pickBestKaminoReserveByMint(connection, mint)` → deepest reserve by `available + (borrowed_sf >> 60)` total supply, returns alternates so caller can switch markets
- Reserve struct field offsets verified across mainnet reserves (RESERVE_TOKEN_INFO_NAME_OFFSET, RESERVE_AVAILABLE_AMOUNT_OFFSET, RESERVE_BORROWED_AMOUNT_SF_OFFSET)

### 2. WebSocket-free confirmation (Helius rate-limit resilient)
- Relayer: `pollForConfirmation()` via `getSignatureStatuses` every 2s with backoff to 5s, 90s ceiling. Replaces `confirmTransaction`'s WS path which got 429'd on Helius free tier.
- SDK: `pendingInputsMode` reads the per-user PDA before submitting commit_inputs; if already populated with the same inputs, skip the redundant tx (idempotent retry).
- MCP: `sendAndPollConfirm()` helper used by ALT bootstrap, owner-PDA pre-fund, owner-ATA create, adapter scratch ATAs, relayer-voucher ATA. Drops the WS dependency from MCP setup paths entirely.

### 3. Per-(viewing_key, mint) obligation derivation
- `derive_owner_pda(adapter, viewing_pub_hash, mint)` — adds mint to the PDA seed list. Each (viewing_key, mint) gets its own Kamino UserMetadata + Obligation.
- Positions are structurally independent: no cross-collateralization, redeem one mint without touching others, no Klend `RefreshObligation` walks-all-reserves problem.
- Mint extracted from `remaining_accounts[0]` (the reserve account, offset 128).
- 8/8 adapter unit tests passing including `same_user_different_mints_get_different_pdas`.

### Verified end-to-end on mainnet
- USDC lend `2uMEoGLaPi18estc5NDHrd2NS2JHT3zDspRLhZZbCK6DNsGMKXuW9N9hQpH8KjN7Sx2SiKSvcTDfa97kNZE1aZjw` Finalized
- SOL lend `4gvqUAy7iAMD4qPaSCkfxrqRv4aoNZ1uwQ68wjtPheZ1EVwdRcFwqtVijfD6B6aQYyjUmkDGXVWGnTfMB5q7XM1d` Finalized
- USDC + SOL coexist as independent obligations on the same viewing key
- Adapter binary deployed: 2enwFgcGKJDqruHpCtvmhtxe3DYcV3k72VTvoGcdt2rX (sig 5hGZBQd3stAwjQBqZNsiUs6GZcvn4nXH8FDYKgeCXPfknihpGFAphyEkMfcK17jnvrsD1jxWkiZVbQWqqGG3ayWg)
- Relayer Cloud Run rev `00006-n4t` live with poll-confirm

### Tests
- `cargo test -p b402-kamino-adapter --features per_user_obligation` — 8/8
- `pnpm --filter @b402ai/solana test` — 65/65
- `pnpm --filter @b402ai/solana-mcp test` — 35/35
- `pnpm --filter @b402ai/solana-relayer test` — 34/34

## Why we missed multi-mint coexistence in PRD-33

PRD-33 scoped to USDC-only. Test suite covered per-user isolation (different users → different PDAs) but never tested the cross-mint dimension (same user, different mint). Klend's RefreshObligation walks every reserve in the obligation's deposits array — implementation detail surfaced only when we lent a second mint after the first.

## Test plan
- [x] Adapter Rust unit tests
- [x] SDK / MCP / relayer TS tests  
- [x] Mainnet USDC lend sig Finalized
- [x] Mainnet SOL lend sig Finalized (independent obligation)
- [ ] Open obligation count check post-merge (sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)