### PR TITLE
Zero-config SDK 0.0.21 — high-level swap/lend/redeem + circuit auto-load

### DIFF
--- a/.claude/skills/b402-private-defi/SKILL.md
+++ b/.claude/skills/b402-private-defi/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: b402-private-defi
+description: Add private swap, private lending (Kamino), or private unshield to a Solana app via @b402ai/solana. Use when the user says "private swap", "shielded", "Kamino private", "b402", or asks for sender/recipient unlinkability on Solana.
+---
+
+# b402 private DeFi on Solana
+
+`@b402ai/solana` is a TypeScript SDK that wraps a shielded UTXO pool +
+adapters on Solana mainnet. It gives end-user apps three primitives the
+underlying chain doesn't expose:
+
+| Method | What it does |
+|---|---|
+| `b402.shield({ mint, amount })`            | public token → shielded note (the user's wallet signs, one-time) |
+| `b402.swap({ inMint, outMint, amount })`   | shielded → shielded via Jupiter routing, relayer pays gas |
+| `b402.lend({ mint, amount, market? })`     | shielded → Kamino reserve (auto-discovered), mint shielded voucher |
+| `b402.redeem({ mint, market?, leafIndex? })` | burn voucher → shielded underlying |
+| `b402.unshield({ to, mint })`              | shielded note → any public address (sender→recipient unlink) |
+
+The privacy property: **only `shield` references the user's wallet on
+chain**. Every other op is signed by the b402 hosted relayer, so the
+on-chain tx contains the relayer's pubkey, the adapter program, the fill
+venue (Phoenix/Raydium/etc.), and the amount — but not the user.
+
+## Integration recipe
+
+```bash
+npm install @b402ai/solana
+```
+
+```typescript
+import { B402Solana } from '@b402ai/solana';
+import { Keypair, PublicKey } from '@solana/web3.js';
+
+const b402 = new B402Solana({
+  cluster: 'mainnet',
+  rpcUrl: process.env.RPC_URL!,   // Helius/Triton; public mainnet-beta throttles
+  keypair,                         // user signs `shield` only
+});
+await b402.ready();                // first call fetches circuit artifacts
+                                   // (~36MB, cached in ~/.b402ai/circuits)
+
+const USDC = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+const SOL  = new PublicKey('So11111111111111111111111111111111111111112');
+
+await b402.shield({ mint: USDC, amount: 1_000_000n });
+const r = await b402.swap({ inMint: USDC, outMint: SOL, amount: 1_000_000n });
+console.log('swap sig:', r.signature, 'out:', r.outAmount.toString());
+```
+
+## Constraints to know before generating code
+
+1. **Mainnet only for `lend`/`redeem`.** Kamino reserves don't exist on
+   devnet. `swap` works on devnet against a mock adapter.
+2. **Exact-value spend.** Today the SDK requires
+   `note.value === amount` exactly. To swap a different amount, shield
+   exactly that amount. Partial-spend lands in a future release.
+3. **First lend per `(viewing key, mint)` tuple costs ~0.04 SOL of
+   Kamino UserMetadata + Obligation rent.** Refundable on close. Every
+   subsequent lend in that reserve costs only the relayer's gas
+   (which the user does not pay).
+4. **Don't manually construct `privateSwap` calls.** Use
+   `b402.swap` / `lend` / `redeem`. The low-level escape hatch exists
+   but is for new-protocol adapter authors, not app integrators.
+
+## Costs
+
+| Op | User pays | Relayer pays |
+|---|---|---|
+| `shield`  | ~5,000 lamports tx fee | — |
+| `swap`    | $0                     | ~10k lamports |
+| `lend`    | $0 (after first-time Kamino rent) | ~10k lamports |
+| `redeem`  | $0                     | ~10k lamports |
+| `unshield`| $0                     | ~10k lamports |
+
+## What's on chain (mainnet, live)
+
+- Pool: `42a3hsCXtQLWonyxWZosaaCJCweYYKMrvNd25p1Jrt2y`
+- Verifier: `Afjbnv2Ekxa98jjRw33xPPhZabevek2uZxoE75kr6ZrK`
+- Jupiter adapter: `3RHRcbinCmcj8JPBfVxb9FW76oh4r8y21aSx4JFy3yx7`
+- Kamino adapter: `2enwFgcGKJDqruHpCtvmhtxe3DYcV3k72VTvoGcdt2rX`
+- Hosted relayer: `https://b402-solana-relayer-mainnet-62092339396.us-central1.run.app`
+
+## When to delegate to MCP instead of writing code
+
+If the user wants to do private operations interactively from their IDE
+without writing app code, suggest installing the MCP server:
+
+```bash
+npx -y @b402ai/solana-mcp@latest --install
+```
+
+Then they prompt the agent ("swap 1 USDC privately for SOL") and the
+agent calls `mcp__b402-solana__private_swap` directly.
+
+## Source layout
+
+- `packages/sdk/src/b402.ts` — `B402Solana` class, all public methods
+- `packages/sdk/src/circuits.ts` — circuit artifact loader (SHA256-pinned)
+- `packages/sdk/src/jupiter-route.ts` — Jupiter route fetcher used by `swap()`
+- `packages/sdk/src/kamino-discover.ts` — on-chain reserve discovery
+- `packages/sdk/src/kamino-mainnet.ts` — Kamino account-list + payload builders
+- `programs/b402-pool/src/` — shielded pool + adapter dispatch
+- `programs/b402-{jupiter,kamino,orca,adrena}-adapter/src/` — per-protocol adapter programs (~200-400 LOC each)
+
+## Reference docs
+
+- `docs/getting-started.md` — full method surface + visible/hidden table
+- `AGENTS.md` — same content for non-Claude agents (Cursor, Codex, Continue, Cline)
+- `docs/TX-WALKTHROUGH.md` — byte-level tx anatomy

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ examples/mainnet-jupiter-swap-demo.ts
 examples/mainnet-phase7-smoke.ts
 examples/mainnet-end-to-end-demo.ts
 examples/mainnet-swap-matrix.ts
+examples/mainnet-add-token-cfg.mjs
 examples/probe-*.mjs
 examples/surfpool-bench.mjs
 examples/devnet-phase7-smoke.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,144 @@
+# AGENTS.md
+
+LLM-readable manifest for `b402-solana`. If you are an AI coding agent
+(Claude Code, Cursor, Codex, Continue, Cline, …) and a user asks you to
+add private DeFi to their Solana app, this file is the canonical
+starting point.
+
+## What this is
+
+`b402-solana` is a shielded pool + composable adapters on Solana mainnet.
+It lets users do private swaps (via Jupiter routing), private lending
+(via Kamino), and private unshields without their wallet appearing on
+the on-chain tx. Sender → recipient unlinkability via Light Protocol
+address tree V2 + Groth16 zk-SNARKs.
+
+## Two integration paths
+
+### 1. App integration (most common)
+
+User wants to add private swap / lend / unshield to their own app. Use
+the `@b402ai/solana` SDK.
+
+```bash
+npm install @b402ai/solana
+```
+
+```typescript
+import { B402Solana } from '@b402ai/solana';
+import { Keypair, PublicKey } from '@solana/web3.js';
+
+const b402 = new B402Solana({
+  cluster: 'mainnet',
+  rpcUrl: process.env.RPC_URL!,    // a private RPC; public mainnet-beta throttles
+  keypair: userKeypair,            // user signs the initial shield only
+});
+await b402.ready();                 // fetches circuit artifacts on first call
+
+// Public → shielded note (user signs once).
+await b402.shield({ mint: USDC, amount: 1_000_000n });
+
+// Private swap. Hosted relayer signs + pays gas, user wallet stays off-chain.
+const swap = await b402.swap({ inMint: USDC, outMint: SOL, amount: 1_000_000n });
+
+// Private lending — auto-discovers the deepest Kamino reserve for the mint.
+const lend = await b402.lend({ mint: USDC, amount: 1_000_000n });
+const redeem = await b402.redeem({ mint: USDC });
+
+// Withdraw a shielded note to ANY public address — sender→recipient unlink.
+await b402.unshield({ to: anyRecipient, mint: USDC });
+```
+
+Full method surface and visible-vs-hidden table:
+[`docs/getting-started.md`](docs/getting-started.md).
+
+### 2. Run-from-IDE (interactive operations)
+
+User wants to do private operations directly from their IDE. Install the
+MCP server.
+
+```bash
+npx -y @b402ai/solana-mcp@latest --install
+```
+
+This wires `b402-solana` into Claude Code / Cursor / any MCP runtime.
+After install, the user can say "swap 1 USDC privately for SOL" and the
+agent calls `mcp__b402-solana__private_swap`.
+
+## What's on chain (mainnet, live)
+
+| Component | Program ID                                   | Notes |
+|---|---|---|
+| Pool      | `42a3hsCXtQLWonyxWZosaaCJCweYYKMrvNd25p1Jrt2y` | Shielded UTXO pool, Light V2 backed |
+| Verifier  | `Afjbnv2Ekxa98jjRw33xPPhZabevek2uZxoE75kr6ZrK` | Groth16 BN254 |
+| Adapter (Jupiter) | `3RHRcbinCmcj8JPBfVxb9FW76oh4r8y21aSx4JFy3yx7` | Routes any Jupiter pair |
+| Adapter (Kamino)  | `2enwFgcGKJDqruHpCtvmhtxe3DYcV3k72VTvoGcdt2rX` | Per-(viewing key, mint) obligation |
+| Relayer   | https://b402-solana-relayer-mainnet.run.app   | Hosted; default for SDK |
+
+## What's free vs paid
+
+- `shield`: user pays ~5,000 lamports (~$0.001) base Solana tx fee.
+- `swap`, `lend`, `redeem`, `unshield`: $0 to user. Hosted relayer pays
+  gas (typically 5-10k lamports per tx).
+- One-time per (viewing key, mint) when first lending on Kamino: ~0.04
+  SOL (~$7) for Kamino UserMetadata + Obligation rent. Refundable via
+  Kamino's `close_obligation` once the position is empty.
+
+## Privacy model — what's hidden vs visible
+
+Visible on chain: **amounts**, **adapter program**, **fill venue**
+(Phoenix / Raydium / etc.), **relayer pubkey**.
+
+Hidden: **depositor identity**, **recipient identity**, **note linkage**
+(no on-chain edge between a shielded deposit and its later unshield).
+
+Anonymity set is bounded by Light Protocol's address tree V2 cohort,
+which `b402-solana` shares with all other Light V2 users on Solana
+mainnet.
+
+## Common tasks for an AI agent
+
+| User asks... | What to do |
+|---|---|
+| "Add private swap to my Next.js app" | Install `@b402ai/solana`, call `b402.shield(...)` then `b402.swap(...)`. See `docs/getting-started.md`. |
+| "Let me lend my shielded USDC privately on Kamino" | Use `b402.lend({ mint: USDC, amount })`. SDK auto-discovers the deepest reserve across all 182 Kamino markets. |
+| "I want to swap privately right now without writing code" | Run `npx -y @b402ai/solana-mcp@latest --install`, then prompt the agent. |
+| "Compare Kamino reserve APYs" | `discoverKaminoReserves(connection)` returns all reserves with `availableAmount` + `totalSupply` per mint. |
+| "How does the privacy work?" | Point at `docs/TX-WALKTHROUGH.md` (byte-level tx anatomy) or `docs/getting-started.md` ("What's visible on chain" table). |
+
+## Source layout (for code-reading agents)
+
+- `packages/sdk/src/b402.ts` — `B402Solana` class, all public methods
+- `packages/sdk/src/jupiter-route.ts` — Jupiter route fetcher used by `swap()`
+- `packages/sdk/src/kamino-discover.ts` — on-chain reserve discovery
+- `packages/sdk/src/kamino.ts` — Kamino account-list + payload builders
+- `programs/b402-pool/src/` — shielded pool + adapter dispatch
+- `programs/b402-{jupiter,kamino,orca,adrena}-adapter/src/` — adapter
+  reference implementations (~200-400 LOC each)
+
+## What NOT to do
+
+- Don't reach into pool/adapter Rust unless you're writing a new adapter
+  for a new protocol. The SDK's `swap` / `lend` / `redeem` cover the
+  user-facing flows.
+- Don't construct `privateSwap` calls manually with raw `adapterIxData` /
+  `remainingAccounts` — that's the low-level escape hatch. Use `swap()`
+  unless you have a specific reason.
+- Don't store the user's viewing key in plaintext anywhere — it's
+  derived deterministically from their wallet's signature on a fixed
+  message; re-derive on each session.
+
+## Versions
+
+- `@b402ai/solana@0.0.21` — high-level `swap()` / `lend()` / `redeem()`,
+  zero-config circuit loader, indexer-aware spent-note filter, default
+  on-disk note-store cursor.
+- `@b402ai/solana-mcp@0.0.28`
+- Circuits pinned to release tag `circuits-v1` on the GitHub repo,
+  SHA256-verified at fetch time.
+- Pool / adapter binary versions tracked in their respective program IDs
+  on `solana program show <id> -u m`.
+
+## License
+
+Apache-2.0.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,120 @@
+# Getting started
+
+Add private DeFi to your Solana app in three lines.
+
+## Install
+
+```bash
+npm install @b402ai/solana
+```
+
+## Your first private swap
+
+```typescript
+import { Keypair, PublicKey } from '@solana/web3.js';
+import { B402Solana } from '@b402ai/solana';
+
+const b402 = new B402Solana({
+  cluster: 'mainnet',
+  rpcUrl: process.env.RPC_URL!,        // Helius / Triton / your own
+  keypair: yourKeypair,                 // user signs the initial shield only
+});
+await b402.ready();   // first call fetches circuit artifacts (~36MB,
+                       // SHA256-verified, cached at ~/.b402ai/circuits)
+
+const USDC = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+const SOL  = new PublicKey('So11111111111111111111111111111111111111112');
+
+// Move public USDC into the shielded pool (one-time, user signs).
+await b402.shield({ mint: USDC, amount: 1_000_000n });
+
+// Private swap — relayer signs + pays gas. Caller wallet stays off-chain.
+const { signature, outAmount } = await b402.swap({
+  inMint: USDC,
+  outMint: SOL,
+  amount: 1_000_000n,
+});
+```
+
+That's the full surface for a private swap.
+
+## What just happened
+
+- `shield`: USDC moves from your wallet into the b402 shielded pool. Your
+  wallet signs this single tx, so the deposit amount is linked to your
+  address. After this, no further tx references your wallet.
+- `swap`: the SDK fetches a Jupiter quote (Phoenix-direct by default),
+  builds the adapter ix, and calls the pool's `adapt_execute_v2`. The
+  hosted b402 relayer signs and pays gas. The on-chain swap tx contains
+  the relayer's pubkey, the adapter program, and the Jupiter route — but
+  not your wallet. Sender→recipient unlinkability is the property.
+
+## What's visible on chain
+
+| Visible                                  | Hidden                                    |
+| ---------------------------------------- | ----------------------------------------- |
+| Amount of the swap                       | Who deposited                             |
+| Adapter program (Jupiter)                | Who receives the SOL note                 |
+| Fill venue (Phoenix, Raydium, …)         | Linkage between USDC deposit and SOL out |
+| Relayer pubkey (paid the gas)            | Your wallet address                       |
+
+## Where this works
+
+- **mainnet**: live. Pool `42a3hsCXt...rt2y`, adapter `2enwFgcGK...t2rX`,
+  relayer hosted at `b402-solana-relayer-mainnet.run.app`.
+- **devnet**: live. Mock adapter (constant-rate fake swap), useful for
+  client wiring tests without real funds.
+- **localnet**: works with a `surfpool` mainnet-fork — see
+  [`docs/REPRODUCE.md`](REPRODUCE.md).
+
+## The full method surface
+
+| Method | What it does | Cost |
+|---|---|---|
+| `b402.shield({ mint, amount })` | public → shielded note | user pays ~5k lamports |
+| `b402.swap({ inMint, outMint, amount })` | shielded → shielded via Jupiter | $0 (relayer pays) |
+| `b402.lend({ mint, amount, market? })` | shielded → Kamino reserve, mint voucher | $0 (relayer pays) + one-time ~$7 Kamino account rent per (viewing key, mint) |
+| `b402.redeem({ mint, market?, leafIndex? })` | burn voucher → shielded underlying | $0 (relayer pays) |
+| `b402.unshield({ to, mint })` | shielded note → public address | $0 (relayer pays) |
+| `b402.balance({ mint? })` | read shielded balance | local-only, no RPC |
+| `b402.holdings({ mint? })` | per-deposit list | local-only |
+| `b402.status({ refresh? })` | wallet pubkey + balances; pass refresh=true to scan chain | local or 1 RPC scan |
+
+## Examples
+
+A complete runnable script lives at
+[`examples/quickstart-private-swap.ts`](../examples/quickstart-private-swap.ts).
+
+```bash
+git clone https://github.com/mmchougule/b402-solana
+cd b402-solana
+pnpm install
+B402_RPC_URL='https://mainnet.helius-rpc.com/?api-key=...' \
+  pnpm exec node --experimental-strip-types examples/quickstart-private-swap.ts
+```
+
+Mainnet sigs from a recent run:
+- Shield: `3HaqLAX76Ff2dh...LNXb` Finalized
+- Swap:   `4cWaWAY1wd3hM...sXt`  Finalized — 50,000 raw USDC → 564,337 lamports SOL via Jupiter→Raydium
+
+## What needs your wallet to sign
+
+Only `shield`. Every other op (`swap`, `lend`, `redeem`, `unshield`)
+goes through the b402 hosted relayer — the relayer signs and pays gas,
+your wallet does not appear on those txs.
+
+If you want to self-pay (e.g. for testing without the hosted relayer),
+pass `relayer: yourKeypair` to the `B402Solana` constructor. The hosted
+relayer is a default convenience, not a requirement.
+
+## Next
+
+- [Lend on Kamino](recipes/private-lend.md) — shielded USDC into any Kamino reserve, multi-market discovered on chain
+- [Use from a coding agent (Claude / Cursor)](../AGENTS.md) — let your IDE write the integration for you via `@b402ai/solana-mcp`
+- [Architecture overview](../README.md#architecture) — pool, adapter, relayer, Light Protocol
+- [Spec docs](prds/) — PRDs for circuit, program, and adapter design
+
+## Help
+
+- Issues: https://github.com/mmchougule/b402-solana/issues
+- Source: https://github.com/mmchougule/b402-solana

--- a/examples/quickstart-private-lend.ts
+++ b/examples/quickstart-private-lend.ts
@@ -1,0 +1,53 @@
+/**
+ * Private lend + redeem on Solana mainnet using @b402ai/solana.
+ *
+ *   shield  → public USDC → shielded note (your wallet signs, one-time)
+ *   lend    → shielded USDC → Kamino reserve (auto-discovered), mint a voucher
+ *   redeem  → burn the voucher → shielded underlying
+ *
+ * Env:
+ *   B402_RPC_URL           required, Helius/Triton mainnet endpoint
+ *   B402_AMOUNT            optional, raw USDC amount (6 decimals). Default 50_000 = 0.05 USDC
+ *   B402_SKIP_SHIELD=1     skip step 1, reuse an existing shielded note
+ *   B402_KEYPAIR_PATH      optional, defaults to ~/.config/solana/id.json
+ *
+ * Run: pnpm exec node --experimental-strip-types examples/quickstart-private-lend.ts
+ */
+import { Keypair, PublicKey } from '@solana/web3.js';
+import { B402Solana } from '@b402ai/solana';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const RPC = process.env.B402_RPC_URL;
+if (!RPC) throw new Error('set B402_RPC_URL to a mainnet endpoint');
+
+const KEYPAIR_PATH = process.env.B402_KEYPAIR_PATH
+  ?? path.join(os.homedir(), '.config', 'solana', 'id.json');
+const keypair = Keypair.fromSecretKey(
+  Uint8Array.from(JSON.parse(fs.readFileSync(KEYPAIR_PATH, 'utf8'))),
+);
+
+const USDC = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+const AMOUNT = BigInt(process.env.B402_AMOUNT ?? '50000');
+
+const b402 = new B402Solana({
+  cluster: 'mainnet',
+  rpcUrl: RPC,
+  keypair,
+});
+
+await b402.ready();
+
+if (!process.env.B402_SKIP_SHIELD) {
+  const sh = await b402.shield({ mint: USDC, amount: AMOUNT });
+  console.log('shield', sh.signature);
+}
+
+const lend = await b402.lend({ mint: USDC, amount: AMOUNT });
+console.log('lend', lend.signature, 'voucher', lend.outAmount.toString());
+
+await new Promise((r) => setTimeout(r, 4000));
+
+const redeem = await b402.redeem({ mint: USDC });
+console.log('redeem', redeem.signature, 'underlying', redeem.outAmount.toString());

--- a/examples/quickstart-private-swap.ts
+++ b/examples/quickstart-private-swap.ts
@@ -1,0 +1,108 @@
+/**
+ * Private swap on Solana mainnet using @b402ai/solana — full end-to-end.
+ *
+ * What "private swap" means here:
+ *   - Public USDC sits in your normal wallet (visible on chain).
+ *   - `shield` moves USDC into a shielded pool. The deposit is recorded
+ *     as a commitment in a Light Protocol address tree; on-chain, the
+ *     amount is visible (you put 0.05 USDC into the pool) but the
+ *     ownership is bound to a Poseidon-hashed viewing key, not your
+ *     wallet address.
+ *   - `swap` spends a shielded note (USDC) → routes through Jupiter
+ *     (Phoenix-direct fill) → mints a fresh shielded note (SOL).
+ *     The hosted relayer signs and pays gas, so the swap tx does NOT
+ *     reference your wallet at all. Sender → recipient unlinkability
+ *     is the property — outside observers can't link the SOL output to
+ *     your USDC deposit.
+ *   - `unshield` (not shown) would later move the SOL out to ANY
+ *     public address — including one different from the depositor.
+ *
+ * Visible on chain: amount, adapter program, Phoenix fill venue.
+ * Hidden: depositor identity, recipient identity, note linkage.
+ *
+ * Prereqs:
+ *   - Solana CLI keypair at ~/.config/solana/id.json with ≥0.05 USDC and a few cents of SOL
+ *   - Helius mainnet RPC URL:
+ *       export B402_RPC_URL='https://mainnet.helius-rpc.com/?api-key=<your-key>'
+ *
+ * Run:
+ *   pnpm exec node --experimental-strip-types examples/quickstart-private-swap.ts
+ *
+ * Total wall-clock: ~15s (shield ~5s + swap ~10s).
+ */
+import { Keypair, PublicKey } from '@solana/web3.js';
+import { B402Solana } from '@b402ai/solana';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const RPC_URL = process.env.B402_RPC_URL;
+if (!RPC_URL) {
+  console.error('B402_RPC_URL required (mainnet, with api-key=<…>).');
+  process.exit(1);
+}
+
+const KEYPAIR_PATH = process.env.B402_KEYPAIR_PATH ?? path.join(os.homedir(), '.config/solana/id.json');
+const keypair = Keypair.fromSecretKey(
+  new Uint8Array(JSON.parse(fs.readFileSync(KEYPAIR_PATH, 'utf8'))),
+);
+
+const USDC = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+const SOL  = new PublicKey('So11111111111111111111111111111111111111112');
+// 0.05 USDC (6 decimals). Bump for larger swaps.
+const AMOUNT = 50_000n;
+
+async function main(): Promise<void> {
+  const b402 = new B402Solana({
+    cluster: 'mainnet',
+    rpcUrl: RPC_URL!,
+    keypair,
+  });
+  await b402.ready();
+
+  // Step 1 — shield: public USDC → shielded note in the b402 pool.
+  // Your wallet signs this (Anchor SPL transfer), so this single tx
+  // links your wallet to the deposit amount. Subsequent ops (swap,
+  // unshield, lend) don't.
+  // Set B402_SKIP_SHIELD=1 to swap an existing shielded note instead.
+  if (process.env.B402_SKIP_SHIELD !== '1') {
+    console.log(`▶ shield ${AMOUNT} USDC raw (~$${Number(AMOUNT) / 1e6}) into the b402 pool`);
+    const shield = await b402.shield({ mint: USDC, amount: AMOUNT });
+    console.log(`  shield sig: ${shield.signature}`);
+  } else {
+    console.log(`▶ skipping shield — refreshing local note store from chain`);
+    await b402.status({ refresh: true });
+  }
+
+  // Step 2 — private swap: shielded USDC note → shielded SOL note.
+  // Hosted relayer signs + pays gas, your wallet does not appear on
+  // this tx. Routing handled automatically — Jupiter quote, Phoenix
+  // fill, ALT, adapter wiring all derived inside the SDK.
+  console.log(`▶ private swap ${AMOUNT} USDC → SOL (relayer signs, your wallet stays off-chain)`);
+  const swap = await b402.swap({
+    inMint: USDC,
+    outMint: SOL,
+    amount: AMOUNT,
+    // Default DEX is Phoenix (smallest account count). Smaller swaps
+    // (~$0.05 and below) tend not to route through Phoenix's lot floor;
+    // widen here to AMM venues that route any size.
+    dexes: 'Phoenix,Raydium',
+  });
+  console.log(`  swap sig:  ${swap.signature}`);
+  console.log(`  out:       ${swap.outAmount} lamports SOL (= ${(Number(swap.outAmount) / 1e9).toFixed(6)} SOL)`);
+
+  // Step 3 — sanity: read your shielded balance to see the new SOL note.
+  // This is local-only (reads SDK note store, no RPC call).
+  const wsolBalance = await b402.balance({ mint: SOL });
+  console.log(`▶ shielded SOL balance: ${wsolBalance.balances[0]?.amount ?? '0'} lamports`);
+  console.log(`  → that SOL note can later be unshielded to ANY public address — including one different from your wallet, breaking the sender→recipient link.`);
+}
+
+main().then(() => process.exit(0)).catch((e) => {
+  console.error('\n❌', e.message ?? e);
+  process.exit(1);
+});

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b402ai/solana-mcp",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Model Context Protocol server exposing the b402 Solana SDK as agent-callable tools (Claude Code, Cursor, any MCP runtime)",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/mcp-server/src/kamino-helpers.ts
+++ b/packages/mcp-server/src/kamino-helpers.ts
@@ -136,9 +136,13 @@ export function obligationFarmPda(farm: PublicKey, obligation: PublicKey): Publi
   )[0];
 }
 
-export function deriveOwnerPda(adapter: PublicKey, hash: Buffer): PublicKey {
+/** Per-(viewing_key, mint) PDA — matches the adapter's `derive_owner_pda`
+ *  in programs/b402-kamino-adapter/src/lib.rs. Each lending position
+ *  keyed by liquidity mint gets its own Kamino UserMetadata + Obligation,
+ *  so positions across mints are structurally independent. */
+export function deriveOwnerPda(adapter: PublicKey, hash: Buffer, mint: PublicKey): PublicKey {
   return PublicKey.findProgramAddressSync(
-    [Buffer.from('b402/v1'), Buffer.from('adapter-owner'), hash], adapter,
+    [Buffer.from('b402/v1'), Buffer.from('adapter-owner'), hash, mint.toBuffer()], adapter,
   )[0];
 }
 
@@ -218,7 +222,7 @@ export function deriveAllPerUser(
   market: PublicKey,
 ): PerUserAccounts {
   const hash = spendingPubToHashBytes(spendingPub);
-  const ownerPda = deriveOwnerPda(KAMINO_ADAPTER, hash);
+  const ownerPda = deriveOwnerPda(KAMINO_ADAPTER, hash, reserve.liquidityMint);
   const isFarmAttached = !reserve.reserveFarmCollateral.equals(PublicKey.default);
   const obl = obligationPda(ownerPda, market);
   return {

--- a/packages/mcp-server/src/kamino-helpers.ts
+++ b/packages/mcp-server/src/kamino-helpers.ts
@@ -19,14 +19,12 @@ import {
   PublicKey,
   SystemProgram,
   Transaction,
-  sendAndConfirmTransaction,
   type AccountMeta,
 } from '@solana/web3.js';
 import {
   TOKEN_PROGRAM_ID,
   createAssociatedTokenAccountIdempotentInstruction,
   getAssociatedTokenAddressSync,
-  getOrCreateAssociatedTokenAccount,
 } from '@solana/spl-token';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -63,6 +61,43 @@ const ALT_PROGRAM = new PublicKey('AddressLookupTab1e1111111111111111111111111')
 const EXECUTE_DISC = Uint8Array.from([130, 221, 242, 154, 13, 193, 189, 29]);
 
 // ── small helpers ─────────────────────────────────────────────────────────────
+/**
+ * Send + confirm a tx without WebSocket subscriptions. web3.js's
+ * `sendAndConfirmTransaction` uses confirmTransaction's WS-based path,
+ * which on Helius free tier returns 429 on the WS upgrade after a few
+ * subs and never delivers the confirmation event — leaving txs to
+ * "expire" even when they Finalized 30s prior. Poll instead.
+ */
+async function sendAndPollConfirm(
+  conn: Connection,
+  tx: Transaction,
+  signers: Keypair[],
+  timeoutMs: number = 90_000,
+): Promise<string> {
+  const bh = await conn.getLatestBlockhash('confirmed');
+  tx.recentBlockhash = bh.blockhash;
+  tx.feePayer = signers[0].publicKey;
+  tx.sign(...signers);
+  const sig = await conn.sendRawTransaction(tx.serialize(), {
+    skipPreflight: false,
+    preflightCommitment: 'confirmed',
+    maxRetries: 3,
+  });
+  const start = Date.now();
+  let interval = 2000;
+  while (Date.now() - start < timeoutMs) {
+    const res = await conn.getSignatureStatuses([sig], { searchTransactionHistory: false });
+    const s = res.value[0];
+    if (s) {
+      if (s.err) throw new Error(`tx ${sig} failed: ${JSON.stringify(s.err)}`);
+      if (s.confirmationStatus === 'confirmed' || s.confirmationStatus === 'finalized') return sig;
+    }
+    await new Promise((r) => setTimeout(r, interval));
+    interval = Math.min(interval * 1.2, 5000);
+  }
+  throw new Error(`tx ${sig} not confirmed within ${timeoutMs / 1000}s`);
+}
+
 function findUtf8(buf: Buffer, needle: string): number {
   const b = Buffer.from(needle, 'utf8');
   for (let i = 0; i < buf.length - b.length; i++) {
@@ -297,7 +332,7 @@ export async function ensureAlt(args: {
     });
     altPubkey = fresh;
     altIsFresh = true;
-    await sendAndConfirmTransaction(args.conn, new Transaction().add(createIx), [args.admin], { commitment: 'finalized' });
+    await sendAndPollConfirm(args.conn, new Transaction().add(createIx), [args.admin]);
     // Wait for ALT to be finalized + visible.
     for (let i = 0; i < 60; i++) {
       const info = await args.conn.getAccountInfo(altPubkey, 'finalized');
@@ -329,7 +364,7 @@ export async function ensureAlt(args: {
         payer: args.admin.publicKey, authority: args.admin.publicKey, lookupTable: altPubkey,
         addresses: targets.slice(i, i + CHUNK),
       });
-      await sendAndConfirmTransaction(args.conn, new Transaction().add(ext), [args.admin], { commitment: 'confirmed' });
+      await sendAndPollConfirm(args.conn, new Transaction().add(ext), [args.admin]);
     }
     // Brief wait so the next tx can resolve via the new entries.
     await new Promise((r) => setTimeout(r, 4000));
@@ -351,7 +386,7 @@ export async function ensurePerUserSetup(args: {
   let adapterFunded = false;
   const aaBal = await args.conn.getBalance(args.adapterAuthority);
   if (aaBal < 0.05 * LAMPORTS_PER_SOL) {
-    await sendAndConfirmTransaction(args.conn,
+    await sendAndPollConfirm(args.conn,
       new Transaction().add(
         SystemProgram.transfer({
           fromPubkey: args.admin.publicKey,
@@ -359,7 +394,7 @@ export async function ensurePerUserSetup(args: {
           lamports: 0.5 * LAMPORTS_PER_SOL,
         }),
       ),
-      [args.admin], { commitment: 'confirmed' },
+      [args.admin],
     );
     adapterFunded = true;
   }
@@ -372,7 +407,7 @@ export async function ensurePerUserSetup(args: {
       args.admin.publicKey, args.perUser.ownerUsdcAta,
       args.perUser.ownerPda, args.reserve.liquidityMint,
     );
-    await sendAndConfirmTransaction(args.conn, new Transaction().add(createAtaIx), [args.admin], { commitment: 'confirmed' });
+    await sendAndPollConfirm(args.conn, new Transaction().add(createAtaIx), [args.admin]);
     ataCreated = true;
   }
 
@@ -387,13 +422,24 @@ export async function ensureAdapterScratchAtas(args: {
   inMint: PublicKey;
   outMint: PublicKey;
 }): Promise<{ adapterInTa: PublicKey; adapterOutTa: PublicKey }> {
-  const inAcc = await getOrCreateAssociatedTokenAccount(
-    args.conn, args.admin, args.inMint, args.adapterAuthority, true,
-  );
-  const outAcc = await getOrCreateAssociatedTokenAccount(
-    args.conn, args.admin, args.outMint, args.adapterAuthority, true,
-  );
-  return { adapterInTa: inAcc.address, adapterOutTa: outAcc.address };
+  const inAta = getAssociatedTokenAddressSync(args.inMint, args.adapterAuthority, true);
+  const outAta = getAssociatedTokenAddressSync(args.outMint, args.adapterAuthority, true);
+  // Idempotent create — both ATAs in one tx if either is missing. Anyone
+  // can pay rent for an ATA owned by anyone else (PDA in this case).
+  const ixs = [];
+  const [inInfo, outInfo] = await Promise.all([
+    args.conn.getAccountInfo(inAta), args.conn.getAccountInfo(outAta),
+  ]);
+  if (!inInfo) ixs.push(createAssociatedTokenAccountIdempotentInstruction(
+    args.admin.publicKey, inAta, args.adapterAuthority, args.inMint,
+  ));
+  if (!outInfo) ixs.push(createAssociatedTokenAccountIdempotentInstruction(
+    args.admin.publicKey, outAta, args.adapterAuthority, args.outMint,
+  ));
+  if (ixs.length > 0) {
+    await sendAndPollConfirm(args.conn, new Transaction().add(...ixs), [args.admin]);
+  }
+  return { adapterInTa: inAta, adapterOutTa: outAta };
 }
 
 // ── ix data builders (deposit / withdraw) ─────────────────────────────────────

--- a/packages/mcp-server/src/kamino-helpers.ts
+++ b/packages/mcp-server/src/kamino-helpers.ts
@@ -130,15 +130,21 @@ export interface ParsedReserve {
   reserveFarmCollateral: PublicKey;
 }
 
-/** Parse a Kamino reserve account's on-chain layout. The byte offsets here
- *  are derived from the kLend Reserve struct. Mainnet-USDC-tested. */
-export function parseReserve(data: Buffer): ParsedReserve {
-  const liquidityMint = new PublicKey(data.subarray(128, 160));
-  const reserveFarmCollateral = new PublicKey(data.subarray(64, 96));
-  let nameOff = findUtf8(data, 'USDC\0');
-  if (nameOff < 0) nameOff = findUtf8(data, 'USD Coin');
-  if (nameOff < 0) throw new Error('TokenInfo.name not found in reserve');
-  const tokenInfoOff = nameOff;
+/** Reserve struct field offsets shared with the SDK's kamino-discover. */
+const RESERVE_LIQUIDITY_MINT_OFFSET = 128;
+const RESERVE_FARM_COLLATERAL_OFFSET = 64;
+const RESERVE_TOKEN_INFO_NAME_OFFSET = 5032;
+
+/** Parse a Kamino reserve account into the per-reserve PDAs the adapter
+ *  needs. Uses fixed struct offsets only — no string-anchor search, so
+ *  it works for any mint (USDC, SOL, JitoSOL, BONK, …). The `market`
+ *  argument is required because the per-reserve sub-PDAs (liquidity
+ *  supply, collateral mint, etc.) are derived from `(market, mint)`. */
+export function parseReserve(data: Buffer, market: PublicKey): ParsedReserve {
+  const liquidityMint = new PublicKey(data.subarray(RESERVE_LIQUIDITY_MINT_OFFSET, RESERVE_LIQUIDITY_MINT_OFFSET + 32));
+  const reserveFarmCollateral = new PublicKey(data.subarray(RESERVE_FARM_COLLATERAL_OFFSET, RESERVE_FARM_COLLATERAL_OFFSET + 32));
+  const tokenInfoOff = RESERVE_TOKEN_INFO_NAME_OFFSET;
+  // Within TokenInfo: name(32) + heuristic(24) + maxAgePriceSeconds(8) + maxAgeTwapSeconds(8) + scopeConfig(...)
   const scopeOff = tokenInfoOff + 32 + 24 + 24;
   const swbOff = scopeOff + 52;
   const pythOff = swbOff + 68;
@@ -149,9 +155,9 @@ export function parseReserve(data: Buffer): ParsedReserve {
   };
   return {
     liquidityMint,
-    liquiditySupply: reservePda('reserve_liq_supply', MARKET, liquidityMint),
-    collateralMint: reservePda('reserve_coll_mint', MARKET, liquidityMint),
-    collateralReserveDestSupply: reservePda('reserve_coll_supply', MARKET, liquidityMint),
+    liquiditySupply: reservePda('reserve_liq_supply', market, liquidityMint),
+    collateralMint: reservePda('reserve_coll_mint', market, liquidityMint),
+    collateralReserveDestSupply: reservePda('reserve_coll_supply', market, liquidityMint),
     pyth: readPk(pythOff),
     switchboardPrice: readPk(swbOff),
     switchboardTwap: readPk(swbOff + 32),
@@ -174,23 +180,36 @@ export interface PerUserAccounts {
 export function deriveAllPerUser(
   spendingPub: bigint,
   reserve: ParsedReserve,
+  market: PublicKey,
 ): PerUserAccounts {
   const hash = spendingPubToHashBytes(spendingPub);
   const ownerPda = deriveOwnerPda(KAMINO_ADAPTER, hash);
   const isFarmAttached = !reserve.reserveFarmCollateral.equals(PublicKey.default);
+  const obl = obligationPda(ownerPda, market);
   return {
     ownerPda,
     userMetadata: userMetadataPda(ownerPda),
-    obligation: obligationPda(ownerPda, MARKET),
-    obligationFarm: isFarmAttached ? obligationFarmPda(reserve.reserveFarmCollateral, obligationPda(ownerPda, MARKET)) : KLEND,
+    obligation: obl,
+    obligationFarm: isFarmAttached ? obligationFarmPda(reserve.reserveFarmCollateral, obl) : KLEND,
     reserveFarmState: isFarmAttached ? reserve.reserveFarmCollateral : KLEND,
+    // Per-mint user ATA owned by ownerPda — was named `ownerUsdcAta` for the
+    // initial USDC-only flow but works for any mint via `reserve.liquidityMint`.
     ownerUsdcAta: getAssociatedTokenAddressSync(reserve.liquidityMint, ownerPda, true),
     isFarmAttached,
   };
 }
 
 // ── ALT bootstrap ─────────────────────────────────────────────────────────────
-const ALT_PERSIST_DEFAULT = path.join(os.homedir(), '.b402-solana', 'kamino-mainnet-alt.json');
+/** Persist one ALT per (market, mint) tuple. Different markets/mints have
+ *  disjoint reserve sub-PDAs; sharing one ALT across mints would force
+ *  re-extends on every switch, eating the 256-entry ALT cap fast. */
+function altPersistPathFor(market: PublicKey, mint: PublicKey): string {
+  return path.join(
+    os.homedir(),
+    '.b402-solana',
+    `kamino-mainnet-alt-${market.toBase58().slice(0, 8)}-${mint.toBase58().slice(0, 8)}.json`,
+  );
+}
 
 /** Load (or create + extend) the persisted ALT for Kamino lend/redeem. The
  *  ALT contains all the static and per-user accounts that the lend/redeem
@@ -198,6 +217,8 @@ const ALT_PERSIST_DEFAULT = path.join(os.homedir(), '.b402-solana', 'kamino-main
 export async function ensureAlt(args: {
   conn: Connection;
   admin: Keypair;
+  market: PublicKey;
+  reserveAddr: PublicKey;
   reserve: ParsedReserve;
   perUser: PerUserAccounts;
   pendingInputsPda: PublicKey;
@@ -214,7 +235,7 @@ export async function ensureAlt(args: {
   };
   altPersistPath?: string;
 }): Promise<PublicKey> {
-  const persistPath = args.altPersistPath ?? ALT_PERSIST_DEFAULT;
+  const persistPath = args.altPersistPath ?? altPersistPathFor(args.market, args.reserve.liquidityMint);
   fs.mkdirSync(path.dirname(persistPath), { recursive: true });
 
   const NULLIFIER_CPI_AUTHORITY = PublicKey.findProgramAddressSync(
@@ -238,7 +259,7 @@ export async function ensureAlt(args: {
     VERIFIER_A,
     KAMINO_ADAPTER, args.adapterAuthority,
     args.adapterInTa, args.adapterOutTa,
-    RESERVE, MARKET, lendingMarketAuthorityPda(MARKET),
+    args.reserveAddr, args.market, lendingMarketAuthorityPda(args.market),
     args.reserve.liquiditySupply, args.reserve.collateralMint,
     args.reserve.collateralReserveDestSupply,
     args.reserve.pyth ?? KLEND, args.reserve.switchboardPrice ?? KLEND,
@@ -411,15 +432,17 @@ export function buildAdapterIxData(inAmount: bigint, expectedOut: bigint, payloa
 
 // ── remaining_accounts builders ──────────────────────────────────────────────
 export function buildDepositRemainingAccounts(args: {
+  market: PublicKey;
+  reserveAddr: PublicKey;
   reserve: ParsedReserve;
   perUser: PerUserAccounts;
 }): AccountMeta[] {
   const { reserve, perUser } = args;
   const isFarm = perUser.isFarmAttached;
   return [
-    { pubkey: RESERVE, isSigner: false, isWritable: true },
-    { pubkey: MARKET, isSigner: false, isWritable: false },
-    { pubkey: lendingMarketAuthorityPda(MARKET), isSigner: false, isWritable: false },
+    { pubkey: args.reserveAddr, isSigner: false, isWritable: true },
+    { pubkey: args.market, isSigner: false, isWritable: false },
+    { pubkey: lendingMarketAuthorityPda(args.market), isSigner: false, isWritable: false },
     { pubkey: reserve.liquiditySupply, isSigner: false, isWritable: true },
     { pubkey: reserve.collateralMint, isSigner: false, isWritable: true },
     { pubkey: reserve.collateralReserveDestSupply, isSigner: false, isWritable: true },
@@ -442,16 +465,18 @@ export function buildDepositRemainingAccounts(args: {
 }
 
 export function buildWithdrawRemainingAccounts(args: {
+  market: PublicKey;
+  reserveAddr: PublicKey;
   reserve: ParsedReserve;
   perUser: PerUserAccounts;
 }): AccountMeta[] {
   const { reserve, perUser } = args;
   const isFarm = perUser.isFarmAttached;
   return [
-    { pubkey: RESERVE, isSigner: false, isWritable: true },                                  // 0
+    { pubkey: args.reserveAddr, isSigner: false, isWritable: true },                         // 0
     { pubkey: perUser.obligation, isSigner: false, isWritable: true },                       // 1
-    { pubkey: MARKET, isSigner: false, isWritable: false },                                  // 2
-    { pubkey: lendingMarketAuthorityPda(MARKET), isSigner: false, isWritable: false },       // 3
+    { pubkey: args.market, isSigner: false, isWritable: false },                             // 2
+    { pubkey: lendingMarketAuthorityPda(args.market), isSigner: false, isWritable: false },  // 3
     { pubkey: reserve.collateralReserveDestSupply, isSigner: false, isWritable: true },      // 4
     { pubkey: reserve.collateralMint, isSigner: false, isWritable: true },                   // 5
     { pubkey: reserve.liquiditySupply, isSigner: false, isWritable: true },                  // 6

--- a/packages/mcp-server/src/schemas.ts
+++ b/packages/mcp-server/src/schemas.ts
@@ -95,14 +95,18 @@ export const watchIncomingInput = z
 
 export const privateLendInput = z
   .object({
-    amount: U64String.describe('USDC amount to lend, in raw units (6 decimals — e.g. 100000 = 0.10 USDC, 1000000 = 1.00 USDC). Mainnet only. The caller must already hold a spendable shielded USDC note ≥ this amount; if a note matching the exact amount exists, it will be used, otherwise the most-recent spendable USDC note is selected. First call by a viewing key pays a one-time ~0.04 SOL for Kamino UserMetadata + Obligation rent (charged to adapter authority pre-funded by the user).'),
-    leafIndex: z.number().int().nonnegative().optional().describe('Optional Merkle leaf index of the specific USDC note to spend. Omit to auto-pick (exact-amount match → most-recent fallback).'),
+    amount: U64String.describe('Amount to lend in raw units (smallest token denomination). E.g. for USDC (6 decimals), 1000000 = 1.00 USDC; for SOL (9 decimals), 1000000000 = 1.00 SOL. Caller must hold a spendable shielded note ≥ this amount in `mint`.'),
+    mint: Base58Pubkey.optional().describe('SPL mint to lend. Default USDC mainnet (EPjFWdd5...). Pass any mint Kamino supports (SOL, JitoSOL, USDT, BONK, etc.) — the reserve is discovered on-chain via `pickBestKaminoReserveByMint`.'),
+    market: Base58Pubkey.optional().describe('Pin a specific Kamino LendingMarket. Without this, the reserve with the largest available_amount across all markets wins; the alternates are returned in the response.'),
+    leafIndex: z.number().int().nonnegative().optional().describe('Optional Merkle leaf index of the specific note to spend. Omit to auto-pick (exact-amount match → most-recent fallback).'),
   })
   .strict();
 
 export const privateRedeemInput = z
   .object({
-    leafIndex: z.number().int().nonnegative().optional().describe('Optional Merkle leaf index of the specific kUSDC voucher note to burn. Omit to use the most-recent. Each prior `private_lend` mints a kUSDC voucher commitment of value == lend amount; redeem burns one and unlocks the deposited USDC plus accrued interest from the per-user obligation.'),
+    mint: Base58Pubkey.optional().describe('Underlying mint of the position to redeem. Default USDC mainnet. Must match the mint that was lent.'),
+    market: Base58Pubkey.optional().describe('Pin a specific Kamino LendingMarket (matching the one used at lend time). Without this, the deepest reserve for the mint is used.'),
+    leafIndex: z.number().int().nonnegative().optional().describe('Optional Merkle leaf index of the specific voucher note to burn. Omit to use the most-recent.'),
   })
   .strict();
 

--- a/packages/mcp-server/src/tools/private_lend.ts
+++ b/packages/mcp-server/src/tools/private_lend.ts
@@ -1,19 +1,18 @@
 /**
- * private_lend — atomic private deposit into Kamino V2 USDC reserve.
+ * private_lend — atomic private deposit into a Kamino V2 reserve.
  *
- * Spends a shielded USDC note + deposits into Kamino + mints a kUSDC
- * voucher commitment. Each viewing key gets its own Kamino Obligation
- * (PRD-33 per-user obligation, derived from owner_pda). Mainnet only.
+ * Caller picks a mint (default USDC). The reserve is discovered on-chain:
+ * if multiple Kamino markets list that mint, the deepest by available
+ * supply wins, and alternates are returned in the response so the agent
+ * can switch markets next time. Pass `market` to pin a specific one.
  *
- * One-time setup performed automatically on first call:
- *   - Pre-fund adapter authority (~0.5 SOL) for Kamino UserMetadata +
- *     Obligation rent
- *   - Create owner_pda's USDC ATA (Kamino enforces token::authority ==
- *     obligationOwner on deposit)
- *   - Create / extend the persisted Address Lookup Table to fit all
- *     account refs in the 1232-byte tx cap
+ * Each viewing key gets its own Kamino Obligation per (mint, market)
+ * tuple. Mainnet only.
  *
- * Subsequent calls reuse all of the above.
+ * Auto-setup (cached per (mint, market) tuple):
+ *   - Pre-fund adapter authority for Kamino UserMetadata + Obligation rent
+ *   - Create owner_pda's <mint> ATA (Kamino requires token::authority == obligationOwner)
+ *   - Create / extend the persisted Address Lookup Table for the (market, reserve) tuple
  */
 
 import * as fs from 'node:fs';
@@ -24,13 +23,14 @@ import { createRpc } from '@lightprotocol/stateless.js';
 import {
   poolConfigPda, adapterRegistryPda, treeStatePda,
   tokenConfigPda, vaultPda, derivePendingInputsPda,
+  pickBestKaminoReserveByMint, findAllKaminoReservesByMint,
 } from '@b402ai/solana';
 import { leToFrReduced, type SpendableNote } from '@b402ai/solana-shared';
 
 import type { B402Context } from '../context.js';
 import type { PrivateLendInput } from '../schemas.js';
 import {
-  POOL, KAMINO_ADAPTER, RESERVE, USDC,
+  POOL, KAMINO_ADAPTER, USDC,
   parseReserve, deriveAllPerUser, ensureAlt, ensurePerUserSetup,
   ensureAdapterScratchAtas, adapterAuthorityPda,
   buildDepositPayload, buildAdapterIxData, buildDepositRemainingAccounts,
@@ -49,8 +49,13 @@ export async function handlePrivateLend(
 ): Promise<{
   signature: string;
   voucherDepositId: string;
+  market: string;
+  marketAlternates?: { market: string; reserve: string; availableAmount: string }[];
+  reserve: string;
+  symbol: string;
   obligationPda: string;
   ownerPda: string;
+  inMint: string;
   inAmount: string;
   outVaultDelta: string;
   setupTxs: string[];
@@ -59,31 +64,29 @@ export async function handlePrivateLend(
     throw new Error(`private_lend is mainnet-only (current cluster: ${ctx.cluster}). Kamino reserves don't exist on devnet/localnet.`);
   }
 
-  // ready() lazily inits the wallet + provers — must run before any
-  // ctx.b402.wallet access (b402.wallet getter throws otherwise).
   await ctx.b402.ready();
 
   const conn = new Connection(ctx.rpcUrl, 'confirmed');
   const admin = loadKeypair();
-  const inMint = USDC;
+  const inMint = input.mint ? new PublicKey(input.mint) : USDC;
   const lendAmount = BigInt(input.amount);
 
-  // SDK 0.0.20 routes commit_inputs through the hosted relayer's
-  // /relay/pool-ix endpoint when configured, so the user wallet stays
-  // off-chain. No monkey-patch needed; just call privateLend below.
-
-  // 1. Read + parse the Kamino USDC reserve.
-  const reserveAcct = await conn.getAccountInfo(RESERVE);
-  if (!reserveAcct) throw new Error(`Kamino USDC reserve ${RESERVE.toBase58()} not on chain`);
-  const reserve = parseReserve(reserveAcct.data);
-  if (!reserve.liquidityMint.equals(USDC)) {
-    throw new Error(`reserve liquidity mint ${reserve.liquidityMint.toBase58()} != USDC`);
+  // 1. Discover the Kamino reserve for this mint. If `market` is pinned,
+  //    only consider that market; otherwise scan all markets and pick
+  //    the deepest by available_amount.
+  const marketFilter = input.market ? { market: new PublicKey(input.market) } : {};
+  const picked = await pickBestKaminoReserveByMint(conn, inMint, marketFilter);
+  if (!picked) {
+    throw new Error(`no Kamino reserve found for mint ${inMint.toBase58()}${input.market ? ` in market ${input.market}` : ''}`);
   }
-  const outMint = reserve.collateralMint; // kUSDC
+  const reserveAddr = picked.best.address;
+  const market = picked.best.market;
+  const reserve = parseReserve(picked.best.data, market);
+  const outMint = reserve.collateralMint; // collateral mint (e.g. kUSDC, kSOL)
 
-  // 2. Derive per-user accounts from the SDK's spending pubkey.
+  // 2. Derive per-user accounts.
   const spendingPub = ctx.b402.wallet.spendingPub;
-  const perUser = deriveAllPerUser(spendingPub, reserve);
+  const perUser = deriveAllPerUser(spendingPub, reserve, market);
   const adapterAuthority = adapterAuthorityPda();
 
   const setupTxs: string[] = [];
@@ -100,10 +103,11 @@ export async function handlePrivateLend(
   if (setup.adapterFunded) setupTxs.push('adapter-funded');
   if (setup.ataCreated) setupTxs.push('owner-ata-created');
 
-  // 5. ALT (lazily extended).
+
+  // 5. ALT (lazily extended, persisted per (market, mint) tuple).
   const [pendingInputsPda] = derivePendingInputsPda(POOL, perUser.ownerPda.toBuffer());
   const altPubkey = await ensureAlt({
-    conn, admin, reserve, perUser, pendingInputsPda,
+    conn, admin, market, reserveAddr, reserve, perUser, pendingInputsPda,
     adapterAuthority, adapterInTa, adapterOutTa, outMint,
     poolHelpers: { poolConfigPda, adapterRegistryPda, treeStatePda, tokenConfigPda, vaultPda },
   });
@@ -143,9 +147,9 @@ export async function handlePrivateLend(
   const actualLendAmount = note.value;
 
   // 7. Build the adapter ix + remaining_accounts.
-  const actionPayload = buildDepositPayload(RESERVE, actualLendAmount);
+  const actionPayload = buildDepositPayload(reserveAddr, actualLendAmount);
   const adapterIxData = buildAdapterIxData(actualLendAmount, 0n, actionPayload);
-  const remainingAccounts = buildDepositRemainingAccounts({ reserve, perUser });
+  const remainingAccounts = buildDepositRemainingAccounts({ market, reserveAddr, reserve, perUser });
 
   // 8. Pool's kUSDC vault delta (informational — should be 0 for stateful adapter).
   const outVaultPda = vaultPda(POOL, outMint);
@@ -176,11 +180,25 @@ export async function handlePrivateLend(
   const postInfo = await conn.getAccountInfo(outVaultPda);
   const postKUsdc = postInfo ? BigInt(postInfo.data.readBigUInt64LE(64)) : 0n;
 
+  // Surface the runner-up markets so the caller can switch next time
+  // without re-discovering. Top 5 only — full list is available via
+  // list_kamino_reserves.
+  const marketAlternates = picked.alternates.slice(0, 5).map((a) => ({
+    market: a.market.toBase58(),
+    reserve: a.address.toBase58(),
+    availableAmount: a.availableAmount.toString(),
+  }));
+
   return {
     signature: lendRes.signature,
     voucherDepositId: lendRes.outNote.commitment.toString(16).padStart(64, '0').slice(0, 16),
+    market: market.toBase58(),
+    ...(marketAlternates.length > 0 ? { marketAlternates } : {}),
+    reserve: reserveAddr.toBase58(),
+    symbol: picked.best.symbol,
     obligationPda: perUser.obligation.toBase58(),
     ownerPda: perUser.ownerPda.toBase58(),
+    inMint: inMint.toBase58(),
     inAmount: actualLendAmount.toString(),
     outVaultDelta: (postKUsdc - preKUsdc).toString(),
     setupTxs,

--- a/packages/mcp-server/src/tools/private_redeem.ts
+++ b/packages/mcp-server/src/tools/private_redeem.ts
@@ -25,11 +25,12 @@ import { leToFrReduced, type SpendableNote } from '@b402ai/solana-shared';
 import type { B402Context } from '../context.js';
 import type { PrivateRedeemInput } from '../schemas.js';
 import {
-  POOL, KAMINO_ADAPTER, RESERVE, USDC,
+  POOL, KAMINO_ADAPTER, USDC,
   parseReserve, deriveAllPerUser, ensureAlt, ensurePerUserSetup,
   ensureAdapterScratchAtas, adapterAuthorityPda,
   buildWithdrawPayload, buildAdapterIxData, buildWithdrawRemainingAccounts,
 } from '../kamino-helpers.js';
+import { pickBestKaminoReserveByMint } from '@b402ai/solana';
 
 function loadKeypair(): Keypair {
   const p = path.resolve(
@@ -56,20 +57,22 @@ export async function handlePrivateRedeem(
 
   const conn = new Connection(ctx.rpcUrl, 'confirmed');
   const admin = loadKeypair();
-  const inMint = USDC;
+  const inMint = input.mint ? new PublicKey(input.mint) : USDC;
 
-  // SDK 0.0.20 routes commit_inputs through hosted relayer's
-  // /relay/pool-ix endpoint — user wallet stays off-chain.
-
-  // 1. Read + parse Kamino reserve.
-  const reserveAcct = await conn.getAccountInfo(RESERVE);
-  if (!reserveAcct) throw new Error(`Kamino USDC reserve ${RESERVE.toBase58()} not on chain`);
-  const reserve = parseReserve(reserveAcct.data);
-  const outMint = reserve.collateralMint; // kUSDC (the input for redeem)
+  // 1. Discover the (market, reserve) tuple — must match what was used at lend.
+  const marketFilter = input.market ? { market: new PublicKey(input.market) } : {};
+  const picked = await pickBestKaminoReserveByMint(conn, inMint, marketFilter);
+  if (!picked) {
+    throw new Error(`no Kamino reserve found for mint ${inMint.toBase58()}${input.market ? ` in market ${input.market}` : ''}`);
+  }
+  const reserveAddr = picked.best.address;
+  const market = picked.best.market;
+  const reserve = parseReserve(picked.best.data, market);
+  const outMint = reserve.collateralMint; // collateral mint (input for redeem — voucher being burned)
 
   // 2. Per-user accounts.
   const spendingPub = ctx.b402.wallet.spendingPub;
-  const perUser = deriveAllPerUser(spendingPub, reserve);
+  const perUser = deriveAllPerUser(spendingPub, reserve, market);
   const adapterAuthority = adapterAuthorityPda();
 
   // 3. Reverse adapter scratch ATAs: adapter_in_ta = kUSDC, adapter_out_ta = USDC.
@@ -100,10 +103,10 @@ export async function handlePrivateRedeem(
     conn, admin, outMint /* kUSDC */, relayerPubkey, true,
   );
 
-  // 6. ALT (extends with per-user PDAs lazily).
+  // 6. ALT (extends with per-user PDAs lazily, persisted per (market, mint)).
   const [pendingInputsPda] = derivePendingInputsPda(POOL, perUser.ownerPda.toBuffer());
   const altPubkey = await ensureAlt({
-    conn, admin, reserve, perUser, pendingInputsPda,
+    conn, admin, market, reserveAddr, reserve, perUser, pendingInputsPda,
     adapterAuthority,
     adapterInTa: wAdapterInTa, adapterOutTa: wAdapterOutTa,
     outMint: inMint, // for ALT purposes, want USDC + kUSDC token configs both included
@@ -135,9 +138,9 @@ export async function handlePrivateRedeem(
   const ktIn = redeemNote.value;
 
   // 8. Build adapter ix + ra_withdraw_per_user.
-  const actionPayload = buildWithdrawPayload(RESERVE, ktIn);
+  const actionPayload = buildWithdrawPayload(reserveAddr, ktIn);
   const adapterIxData = buildAdapterIxData(ktIn, 0n, actionPayload);
-  const remainingAccounts = buildWithdrawRemainingAccounts({ reserve, perUser });
+  const remainingAccounts = buildWithdrawRemainingAccounts({ market, reserveAddr, reserve, perUser });
 
   // 9. Pool's USDC vault delta — actual USDC redeemed.
   const usdcVaultPda = vaultPda(POOL, inMint);

--- a/packages/mcp-server/src/tools/private_redeem.ts
+++ b/packages/mcp-server/src/tools/private_redeem.ts
@@ -13,8 +13,11 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { Connection, Keypair, PublicKey } from '@solana/web3.js';
-import { getOrCreateAssociatedTokenAccount } from '@solana/spl-token';
+import { Connection, Keypair, PublicKey, Transaction } from '@solana/web3.js';
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAssociatedTokenAddressSync,
+} from '@solana/spl-token';
 import { createRpc } from '@lightprotocol/stateless.js';
 import {
   poolConfigPda, adapterRegistryPda, treeStatePda,
@@ -99,9 +102,33 @@ export async function handlePrivateRedeem(
   const relayerPubkey = sdkInternal._relayerHttp?.client.pubkey
     ?? sdkInternal.relayer?.publicKey
     ?? admin.publicKey;
-  await getOrCreateAssociatedTokenAccount(
-    conn, admin, outMint /* kUSDC */, relayerPubkey, true,
-  );
+  // Idempotent ATA create — only sends a tx if missing. Avoids
+  // getOrCreateAssociatedTokenAccount's WS-based confirm.
+  const relayerVoucherAta = getAssociatedTokenAddressSync(outMint, relayerPubkey, true);
+  const existing = await conn.getAccountInfo(relayerVoucherAta);
+  if (!existing) {
+    const tx = new Transaction().add(
+      createAssociatedTokenAccountIdempotentInstruction(
+        admin.publicKey, relayerVoucherAta, relayerPubkey, outMint,
+      ),
+    );
+    const bh = await conn.getLatestBlockhash('confirmed');
+    tx.recentBlockhash = bh.blockhash;
+    tx.feePayer = admin.publicKey;
+    tx.sign(admin);
+    const sig = await conn.sendRawTransaction(tx.serialize(), { skipPreflight: false, preflightCommitment: 'confirmed' });
+    // Poll for confirm without WS subs.
+    const start = Date.now();
+    let interval = 2000;
+    while (Date.now() - start < 90_000) {
+      const r = await conn.getSignatureStatuses([sig], { searchTransactionHistory: false });
+      const s = r.value[0];
+      if (s?.confirmationStatus === 'confirmed' || s?.confirmationStatus === 'finalized') break;
+      if (s?.err) throw new Error(`relayer voucher ATA tx failed: ${JSON.stringify(s.err)}`);
+      await new Promise((r) => setTimeout(r, interval));
+      interval = Math.min(interval * 1.2, 5000);
+    }
+  }
 
   // 6. ALT (extends with per-user PDAs lazily, persisted per (market, mint)).
   const [pendingInputsPda] = derivePendingInputsPda(POOL, perUser.ownerPda.toBuffer());

--- a/packages/relayer/src/index.ts
+++ b/packages/relayer/src/index.ts
@@ -46,7 +46,16 @@ export async function buildServer() {
     trustProxy: true,
   });
 
-  const connection = new Connection(cfg.rpcUrl, 'confirmed');
+  // confirmTransactionInitialTimeout = how long web3.js waits for the
+  // first confirmation before declaring the tx unconfirmed. The default
+  // (~30s) is too tight for current mainnet — Kamino lend's commit_inputs
+  // sub-tx can take 25-40s under typical Helius load and the strict 30s
+  // races the network. 90s gives enough buffer that the relayer surfaces
+  // the actual signature back to the SDK before timing out.
+  const connection = new Connection(cfg.rpcUrl, {
+    commitment: 'confirmed',
+    confirmTransactionInitialTimeout: 90_000,
+  });
   const auth = new Authenticator(cfg);
   const submitter = new RpcSubmitter({
     connection,

--- a/packages/relayer/src/submit.ts
+++ b/packages/relayer/src/submit.ts
@@ -186,13 +186,17 @@ export class RpcSubmitter implements Submitter {
     } catch (e) {
       throw Errors.rpcFailure(`sendRawTransaction failed: ${(e as Error).message}`);
     }
-    const conf = await connection.confirmTransaction(sig, 'confirmed');
-    if (conf.value.err) {
-      throw Errors.rpcFailure(`tx failed on-chain: ${JSON.stringify(conf.value.err)}`, { signature: sig });
+    // Use HTTP-poll confirmation instead of confirmTransaction's WS path.
+    // WS subscriptions get rate-limited hard on Helius's free tier (we
+    // observed 19+ ws 429s per attempt under load). Polling is a single
+    // getSignatureStatuses HTTP call per check — way friendlier.
+    const conf = await pollForConfirmation(connection, sig, 90_000);
+    if (conf.err) {
+      throw Errors.rpcFailure(`tx failed on-chain: ${JSON.stringify(conf.err)}`, { signature: sig });
     }
     return {
       signature: sig,
-      slot: conf.context.slot,
+      slot: conf.slot,
       confirmedAt: new Date().toISOString(),
     };
   }
@@ -224,16 +228,57 @@ export class RpcSubmitter implements Submitter {
     // polled via getSignatureStatuses against the embedded tx — here we
     // recompute the signature locally from the wire bytes.
     const sig = recoverFirstSignature(wire);
-    const confirmed = await this.deps.connection.confirmTransaction(sig, 'confirmed');
-    if (confirmed.value.err) {
-      throw Errors.rpcFailure(`tx failed on-chain (jito): ${JSON.stringify(confirmed.value.err)}`, { signature: sig });
+    const confirmed = await pollForConfirmation(this.deps.connection, sig, 90_000);
+    if (confirmed.err) {
+      throw Errors.rpcFailure(`tx failed on-chain (jito): ${JSON.stringify(confirmed.err)}`, { signature: sig });
     }
     return {
       signature: sig,
-      slot: confirmed.context.slot,
+      slot: confirmed.slot,
       confirmedAt: new Date().toISOString(),
     };
   }
+}
+
+/**
+ * HTTP-poll for a tx signature reaching `confirmed` status. Replaces
+ * `connection.confirmTransaction` for relayer use because the latter
+ * uses a WebSocket subscription that gets rate-limited on shared RPC
+ * endpoints (Helius free tier returns 429 on the ws upgrade after a
+ * few open subs, leaving the SDK never seeing the confirmation event
+ * even when the tx Finalized 60s ago).
+ *
+ * Strategy: getSignatureStatuses every `interval` ms with a gentle
+ * backoff up to 5s. One HTTP call per poll, no WS state held open.
+ *
+ * Note: `confirmed` is sufficient for our pool-ix flows — adapter CPIs
+ * land or revert atomically; once a tx is confirmed it won't reorg out
+ * in practice (Solana finality after 31 confirmations ~ 13s).
+ */
+async function pollForConfirmation(
+  connection: import('@solana/web3.js').Connection,
+  signature: string,
+  timeoutMs: number,
+): Promise<{ slot: number; err: unknown }> {
+  const start = Date.now();
+  let interval = 2000;
+  while (Date.now() - start < timeoutMs) {
+    const res = await connection.getSignatureStatuses([signature], { searchTransactionHistory: false });
+    const s = res.value[0];
+    if (s) {
+      if (s.err) return { slot: s.slot, err: s.err };
+      if (s.confirmationStatus === 'confirmed' || s.confirmationStatus === 'finalized') {
+        return { slot: s.slot, err: null };
+      }
+    }
+    await new Promise((r) => setTimeout(r, interval));
+    // Gentle backoff: 2s → 2.4 → 2.88 → 3.46 → 4.15 → 4.99 → 5 (capped).
+    interval = Math.min(interval * 1.2, 5000);
+  }
+  throw Errors.rpcFailure(
+    `tx not confirmed within ${timeoutMs / 1000}s — check signature on Solscan, may have landed but poll timed out`,
+    { signature },
+  );
 }
 
 /** Recover the first signature from a serialised v0 tx — the fee-payer sig.

--- a/packages/relayer/test/submit.test.ts
+++ b/packages/relayer/test/submit.test.ts
@@ -43,6 +43,18 @@ function fakeConnection(overrides: Partial<{
       value: { err: confirmErr },
       context: { slot },
     })),
+    // pollForConfirmation in submit.ts uses getSignatureStatuses now
+    // (replaces the WS-based confirmTransaction). Fake confirms on first
+    // poll so tests don't sleep through the backoff loop.
+    getSignatureStatuses: vi.fn(async (_sigs: string[]) => ({
+      value: [{
+        slot,
+        confirmations: 1,
+        err: confirmErr,
+        confirmationStatus: 'confirmed',
+      }],
+      context: { slot },
+    })),
     getSlot: vi.fn(async () => slot),
     getBalance: vi.fn(async () => 1_000_000_000),
   } as unknown as Connection;

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -19,28 +19,47 @@ npm install @b402ai/solana
 
 ## Quick start
 
-```ts
-import { Keypair, PublicKey } from '@solana/web3.js';
-import { B402Solana } from '@b402ai/solana';
+Three-line private swap on mainnet:
 
-const b402 = new B402Solana({
-  cluster: 'devnet',
-  keypair: Keypair.fromSecretKey(/* ... */),
-  proverArtifacts: {
-    wasmPath: '/abs/path/to/circuits/build/transact_js/transact.wasm',
-    zkeyPath: '/abs/path/to/circuits/build/ceremony/transact_final.zkey',
-  },
-});
+```ts
+import { B402Solana } from '@b402ai/solana';
+import { Keypair, PublicKey } from '@solana/web3.js';
+
+const b402 = new B402Solana({ cluster: 'mainnet', rpcUrl, keypair });
 await b402.ready();
 
-const usdc = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
-const { signature } = await b402.shield({ mint: usdc, amount: 1_000_000n });
-console.log('shielded:', signature);
+const USDC = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+const SOL  = new PublicKey('So11111111111111111111111111111111111111112');
 
-const { balances } = await b402.balance({ mint: usdc });
-console.log('private balance:', balances);
+// Move public USDC into the shielded pool (user signs, one-time).
+await b402.shield({ mint: USDC, amount: 1_000_000n });
 
-await b402.unshield({ to: keypair.publicKey });
+// Private swap. Hosted relayer signs + pays gas; user wallet stays off-chain.
+const { signature, outAmount } = await b402.swap({
+  inMint: USDC, outMint: SOL, amount: 1_000_000n,
+});
+```
+
+Full walkthrough: [`docs/getting-started.md`](https://github.com/mmchougule/b402-solana/blob/main/docs/getting-started.md).
+Runnable example: [`examples/quickstart-private-swap.ts`](https://github.com/mmchougule/b402-solana/blob/main/examples/quickstart-private-swap.ts).
+
+### Lend privately on Kamino
+
+`b402.lend()` auto-discovers the deepest Kamino reserve for the mint
+across all 182 LendingMarkets — no static reserve list. Pass `market`
+to pin a specific one.
+
+```ts
+const lend = await b402.lend({ mint: USDC, amount: 1_000_000n });
+const redeem = await b402.redeem({ mint: USDC });
+```
+
+### Withdraw to a different recipient
+
+```ts
+// The SOL note from `swap` can land at ANY public address — breaking
+// the on-chain edge between depositor and recipient.
+await b402.unshield({ to: someOtherWallet, mint: SOL });
 ```
 
 For a working scaffold:

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b402ai/solana",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Private DeFi on Solana — shielded pool + composable adapters + agent-callable surface",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/sdk/src/b402.ts
+++ b/packages/sdk/src/b402.ts
@@ -76,6 +76,8 @@ import { commitmentHash, feeBindHash, nullifierHash, poseidonTagged } from './po
 import { computeExcessCommitment, deriveExcessRandom } from './excess.js';
 import { encryptNote } from './note-encryption.js';
 import { B402Error, B402ErrorCode } from './errors.js';
+import * as nodeOs from 'node:os';
+import * as nodePath from 'node:path';
 import {
   B402_NULLIFIER_PROGRAM_ID,
   buildCreateNullifierIx,
@@ -415,10 +417,42 @@ export class B402Solana {
     // `this.relayer != null` and throw with a clear error pointing to
     // the missing config.
     this.relayer = config.relayer ?? this.keypair ?? null;
-    this.notesPersistDir = config.notesPersistDir;
-    this.relayerHttpUrl = config.relayerHttpUrl;
-    this.relayerApiKey = config.relayerApiKey;
-    this.inlineCpiNullifier = config.inlineCpiNullifier ?? false;
+    // Default note-store persistence to ~/.b402ai/notes/<cluster>/ so the
+    // backfill cursor survives across runs — turning the typical refresh
+    // call from O(30 RPC calls) into O(1). Pass `notesPersistDir: ''` to
+    // disable (e.g. ephemeral CI). Skipped in non-Node envs where `os` is
+    // unavailable.
+    if (config.notesPersistDir !== undefined) {
+      this.notesPersistDir = config.notesPersistDir || undefined;
+    } else {
+      try {
+        this.notesPersistDir = nodePath.join(nodeOs.homedir(), '.b402ai', 'notes', config.cluster);
+      } catch {
+        this.notesPersistDir = undefined;
+      }
+    }
+    // Cluster-aware defaults so app devs don't have to configure a
+    // relayer to do their first private op. Override via config or pass
+    // empty string to disable. Public-tier API key (5 req/min) ships
+    // baked in — same key the MCP server defaults to.
+    const clusterDefaultRelayerUrl: Record<typeof config.cluster, string | undefined> = {
+      mainnet: 'https://b402-solana-relayer-mainnet-62092339396.us-central1.run.app',
+      devnet:  'https://b402-solana-relayer-devnet-62092339396.us-central1.run.app',
+      localnet: undefined,
+    };
+    const clusterDefaultApiKey: Record<typeof config.cluster, string | undefined> = {
+      mainnet: 'kp_53d31f4d4b758ea2',
+      devnet:  'kp_8a28d0e86074cde3',
+      localnet: undefined,
+    };
+    this.relayerHttpUrl = config.relayerHttpUrl === '' ? undefined
+      : (config.relayerHttpUrl ?? clusterDefaultRelayerUrl[config.cluster]);
+    this.relayerApiKey = config.relayerApiKey === '' ? undefined
+      : (config.relayerApiKey ?? clusterDefaultApiKey[config.cluster]);
+    // Phase 7B mainnet pool requires inline-CPI mode; default ON for
+    // mainnet/devnet so the first call works, override only for local
+    // bench-style configurations.
+    this.inlineCpiNullifier = config.inlineCpiNullifier ?? (config.cluster !== 'localnet');
     // Indexer is opt-in. When set, the SDK uses /v1/proof to support
     // spend-any-leaf; on indexer error it logs and falls back to the
     // rightmost-only proveMostRecentLeaf so a transient outage doesn't
@@ -426,9 +460,19 @@ export class B402Solana {
     // NOTE: must be a STATIC import (top of file). The package is
     // `"type": "module"` so `require` is undefined at runtime — using it
     // here was the 0.0.13 bug that broke MCP startup on every tool call.
-    this.indexer = config.indexerUrl
+    // Default indexer URL by cluster — gives `proveMostRecentLeaf`
+    // fallback the indexer-backed real-Merkle-path resolver, so older
+    // (non-rightmost) notes are spendable. Override with empty string.
+    const clusterDefaultIndexerUrl: Record<typeof config.cluster, string | undefined> = {
+      mainnet: 'https://b402-solana-indexer-api-62092339396.us-central1.run.app',
+      devnet: undefined, // no devnet indexer deployed yet
+      localnet: undefined,
+    };
+    const indexerUrl = config.indexerUrl === '' ? undefined
+      : (config.indexerUrl ?? clusterDefaultIndexerUrl[config.cluster]);
+    this.indexer = indexerUrl
       ? new B402Indexer({
-          url: config.indexerUrl,
+          url: indexerUrl,
           connection: this.connection,
           poolProgramId: new PublicKey(this.programIds.b402Pool),
         })
@@ -453,6 +497,16 @@ export class B402Solana {
 
   /** Lazy-init wallet + note store. Idempotent. */
   async ready(): Promise<void> {
+    // Auto-resolve circuit artifacts on first ready() if the caller didn't
+    // pass any. Cached at ~/.b402ai/circuits/<sha>/ — first install pays
+    // a one-time ~36MB fetch from the GitHub release; subsequent runs are
+    // local. Hashes are pinned in src/circuits.ts and verified before use.
+    if (!this._prover || !this._adaptProver) {
+      const { resolveAllCircuits } = await import('./circuits.js');
+      const c = await resolveAllCircuits();
+      if (!this._prover) this._prover = new TransactProver(c.transact);
+      if (!this._adaptProver) this._adaptProver = new AdaptProver(c.adapt);
+    }
     if (!this._wallet) {
       // Deterministic b402 wallet seeded from the active signer. For
       // KeypairSigner this is `keypair.secretKey[0..32]` (preserves
@@ -628,6 +682,26 @@ export class B402Solana {
     this._notes!.insertNote(result.note);
     // Remember the mint for future Fr→base58 resolution.
     this.learnMint(req.mint);
+
+    // Wait until the indexer reflects this shield. Otherwise a follow-up
+    // swap/lend that does `proveLeaf` for the new commitment hits a
+    // 404 and falls through to proveMostRecentLeaf — which then fails
+    // because on-chain TreeState may not have advanced through the user's
+    // RPC yet either. Bounded poll so a slow indexer doesn't hang the
+    // shield call indefinitely.
+    if (this.indexer) {
+      const target = BigInt(result.note.leafIndex);
+      const deadline = Date.now() + 30_000;
+      while (Date.now() < deadline) {
+        try {
+          const s = await this.indexer.state();
+          if (BigInt(s.leafCount) > target) break;
+        } catch {
+          // ignore — try again
+        }
+        await new Promise((r) => setTimeout(r, 1500));
+      }
+    }
     return result;
   }
 
@@ -853,29 +927,60 @@ export class B402Solana {
     if (req.note) {
       note = req.note;
     } else {
-      const candidates = this._notes!.getSpendable(inMintFr);
+      let candidates = this._notes!.getSpendable(inMintFr);
       if (candidates.length === 0) {
         throw new B402Error(
           B402ErrorCode.NoSpendableNotes,
           `no private deposit in mint ${req.inMint.toBase58().slice(0, 8)}…`,
         );
       }
+      // Cross-check the value-matching candidates against the indexer's
+      // spent set. Local `markSpent` only fires after a SDK-orchestrated tx
+      // confirms; notes spent in a prior session (or by a different SDK
+      // instance with the same viewing key) look spendable locally but the
+      // nullifier is already on chain. We probe ONLY notes whose value
+      // matches `req.amount` (those are the actual candidates the picker
+      // below will choose from), in newest-first order, and stop as soon
+      // as we find an unspent one — keeps it to ~1 HTTP call in the happy
+      // path.
+      if (this.indexer) {
+        const matchValue = candidates
+          .filter((n) => n.value === req.amount)
+          .sort((a, b) => Number(BigInt(b.leafIndex) - BigInt(a.leafIndex)));
+        for (const n of matchValue) {
+          try {
+            const nh = await nullifierHash(this._wallet!.spendingPriv, n.leafIndex);
+            if (await this.indexer.isSpent(nh)) {
+              this._notes!.markSpent(n.commitment);
+              continue;
+            }
+            note = n;
+            break;
+          } catch {
+            // Indexer transient failure: fall through, picker below decides.
+            break;
+          }
+        }
+      }
+      // Fall-through picker (no indexer, or indexer probe didn't pick).
       // Exact-value match required. Among matches, pick the rightmost leaf
       // (highest leafIndex) — `proveMostRecentLeaf` only validates for the
       // rightmost; older leaves with newer leaves to their right strand
       // until we ship the indexer-backed real-Merkle-path resolver.
-      const matches = candidates.filter((n) => n.value === req.amount);
-      const sortedDesc = [...matches].sort((a, b) =>
-        Number(BigInt(b.leafIndex) - BigInt(a.leafIndex)),
-      );
-      note = sortedDesc[0];
       if (!note) {
-        const sizes = candidates.map((n) => n.value.toString()).join(', ');
-        throw new B402Error(
-          B402ErrorCode.InvalidConfig,
-          `private_swap requires an exact-match deposit. Available deposit sizes for this mint: [${sizes}]. Requested: ${req.amount}. ` +
-          `To swap a different amount, first shield exactly that amount, or unshield and reshield to split.`,
+        const matches = candidates.filter((n) => n.value === req.amount);
+        const sortedDesc = [...matches].sort((a, b) =>
+          Number(BigInt(b.leafIndex) - BigInt(a.leafIndex)),
         );
+        note = sortedDesc[0];
+        if (!note) {
+          const sizes = candidates.map((n) => n.value.toString()).join(', ');
+          throw new B402Error(
+            B402ErrorCode.InvalidConfig,
+            `private_swap requires an exact-match deposit. Available deposit sizes for this mint: [${sizes}]. Requested: ${req.amount}. ` +
+            `To swap a different amount, first shield exactly that amount, or unshield and reshield to split.`,
+          );
+        }
       }
     }
     if (note.value !== req.amount) {
@@ -1407,14 +1512,349 @@ export class B402Solana {
   }
 
   /**
-   * Lend underlying tokens into a registered yield protocol via its
-   * adapter. Mechanically a `privateSwap`: burns one note in `inMint`
-   * (the underlying), CPIs the adapter with a Deposit action, and
-   * reshields proceeds in `outMint` (the receipt token, e.g. kUSDC).
+   * Atomic private swap with auto-routing. Burns a shielded note in
+   * `inMint`, routes through Jupiter (Phoenix-direct on mainnet), and
+   * reshields the proceeds into a new note in `outMint`. Hosted relayer
+   * pays gas — caller wallet stays off-chain.
    *
-   * Caller still constructs `adapterIxData` + `remainingAccounts` for
-   * the target adapter. For Kamino, see `buildKaminoDepositIx` in
-   * `@b402ai/solana/kamino`.
+   * Minimal call shape:
+   * ```
+   * const r = await b402.swap({ inMint: USDC, outMint: SOL, amount: 1_000_000n });
+   * ```
+   *
+   * On mainnet this fetches a Jupiter quote, builds the adapter ix data
+   * + remaining_accounts from the quote, and calls `privateSwap` under
+   * the hood. On devnet falls through to the constant-rate mock adapter.
+   *
+   * Note value constraint: caller must hold a shielded note in `inMint`
+   * with value EXACTLY equal to `amount`. The SDK selects it
+   * automatically (most-recent leaf wins on ties).
+   */
+  async swap(req: {
+    inMint: PublicKey;
+    outMint: PublicKey;
+    amount: bigint;
+    /** Slippage tolerance in basis points. Default 30 (0.3%). */
+    slippageBps?: number;
+    /** Override expected OUT amount. Default: derived from Jupiter quote
+     *  with `slippageBps` applied as the floor. */
+    expectedOut?: bigint;
+    /** DEX allowlist for Jupiter routing. Default Phoenix (smallest
+     *  account count, fits the 1232 B tx cap reliably). */
+    dexes?: string;
+  }): Promise<PrivateSwapResult> {
+    await this.ready();
+
+    const { fetchJupiterRoute } = await import('./jupiter-route.js');
+    const { B402_ALT_MAINNET, B402_ALT_DEVNET } = await import('@b402ai/solana-shared');
+    const { getAssociatedTokenAddress } = await import('@solana/spl-token');
+    const { createRpc } = await import('@lightprotocol/stateless.js');
+
+    const adapterProgramId = new PublicKey(
+      this.cluster === 'mainnet'
+        ? this.programIds.b402JupiterAdapter
+        : this.programIds.b402MockAdapter,
+    );
+    const adapterAuthority = PublicKey.findProgramAddressSync(
+      [new TextEncoder().encode('b402/v1'), new TextEncoder().encode('adapter')],
+      adapterProgramId,
+    )[0];
+    const adapterInTa = await getAssociatedTokenAddress(req.inMint, adapterAuthority, true);
+    const adapterOutTa = await getAssociatedTokenAddress(req.outMint, adapterAuthority, true);
+
+    const altStr =
+      this.cluster === 'mainnet' ? B402_ALT_MAINNET :
+      this.cluster === 'devnet' ? B402_ALT_DEVNET : '';
+    if (!altStr) {
+      throw new Error(`b402.swap: no canonical Address Lookup Table for cluster ${this.cluster}. Use the lower-level privateSwap() and pass alt explicitly.`);
+    }
+    const alt = new PublicKey(altStr);
+
+    const photonRpc = createRpc(this.connection.rpcEndpoint, this.connection.rpcEndpoint);
+
+    let expectedOut = req.expectedOut;
+    let adapterIxData: Uint8Array | undefined;
+    let actionPayload: Uint8Array | undefined;
+    let remainingAccounts: Array<{ pubkey: PublicKey; isSigner: boolean; isWritable: boolean }> | undefined;
+    let extraAlts: PublicKey[] = [];
+
+    if (this.cluster === 'mainnet') {
+      const slippageBps = req.slippageBps ?? 30;
+      const route = await fetchJupiterRoute({
+        inMint: req.inMint,
+        outMint: req.outMint,
+        amount: req.amount,
+        slippageBps,
+        userPublicKey: adapterAuthority,
+        ...(req.dexes !== undefined ? { dexes: req.dexes } : {}),
+      });
+      const jupIxData = new Uint8Array(Buffer.from(route.swap.swapInstruction.data, 'base64'));
+      const u32Le = (n: number) => { const b = Buffer.alloc(4); b.writeUInt32LE(n, 0); return b; };
+      const u64Le = (v: bigint) => { const b = Buffer.alloc(8); b.writeBigUInt64LE(v, 0); return b; };
+      adapterIxData = new Uint8Array(Buffer.concat([
+        Buffer.from(instructionDiscriminator('execute')),
+        u64Le(req.amount), u64Le(0n),
+        u32Le(jupIxData.length), jupIxData,
+      ]));
+      actionPayload = jupIxData;
+      remainingAccounts = route.swap.swapInstruction.accounts.map((a) => ({
+        pubkey: new PublicKey(a.pubkey), isSigner: false, isWritable: a.isWritable,
+      }));
+      extraAlts = (route.swap.addressLookupTableAddresses ?? []).map((s) => new PublicKey(s));
+      // Pool enforces actual_out >= expected_out. Use Jupiter's
+      // otherAmountThreshold (= outAmount × (1 − slippageBps/10000)).
+      expectedOut = expectedOut ?? BigInt(route.quote.otherAmountThreshold ?? route.quote.outAmount);
+    }
+
+    return this.privateSwap({
+      inMint: req.inMint,
+      outMint: req.outMint,
+      amount: req.amount,
+      adapterProgramId,
+      adapterInTa,
+      adapterOutTa,
+      alt,
+      photonRpc,
+      ...(expectedOut !== undefined ? { expectedOut } : {}),
+      ...(adapterIxData !== undefined ? { adapterIxData } : {}),
+      ...(actionPayload !== undefined ? { actionPayload } : {}),
+      ...(remainingAccounts !== undefined ? { remainingAccounts } : {}),
+      ...(extraAlts.length > 0 ? { alts: extraAlts } : {}),
+      // Phase 9 mainnet pool requires both. Legacy paths only for devnet
+      // mock adapter and historical testing.
+      phase9DualNote: this.cluster === 'mainnet',
+      pendingInputsMode: this.cluster === 'mainnet',
+    });
+  }
+
+  /**
+   * Atomic private lend into a Kamino V2 reserve. Auto-discovers the
+   * deepest reserve for `mint` across all 182 mainnet LendingMarkets,
+   * derives per-(viewing key, mint) Kamino obligation, runs the deposit
+   * + voucher mint in one tx. Pass `market` to pin a specific one
+   * (e.g. JLP-only).
+   *
+   * Minimal call shape:
+   * ```
+   * const r = await b402.lend({ mint: USDC, amount: 1_000_000n });
+   * ```
+   *
+   * First call per (viewing key, mint) tuple incurs ~0.04 SOL one-time
+   * Kamino UserMetadata + Obligation rent (refundable on close).
+   * Subsequent lends in that reserve cost only the relayer's tx fees.
+   *
+   * Mainnet only. Devnet has no Kamino reserves.
+   */
+  async lend(req: {
+    mint: PublicKey;
+    amount: bigint;
+    /** Pin a specific Kamino LendingMarket. If unset, the deepest
+     *  reserve (by available + borrowed total supply) wins. */
+    market?: PublicKey;
+  }): Promise<PrivateSwapResult> {
+    if (this.cluster !== 'mainnet') {
+      throw new B402Error(B402ErrorCode.InvalidConfig,
+        `b402.lend is mainnet-only (current cluster: ${this.cluster}). Kamino reserves don't exist on devnet/localnet.`);
+    }
+    await this.ready();
+    await this.status({ refresh: true });
+    const admin = this._requireRelayer('b402.lend (Kamino setup txs)');
+    const { pickBestKaminoReserveByMint } = await import('./kamino-discover.js');
+    const km = await import('./kamino-mainnet.js');
+    const { createRpc } = await import('@lightprotocol/stateless.js');
+
+    const picked = await pickBestKaminoReserveByMint(
+      this.connection, req.mint,
+      req.market ? { market: req.market } : {},
+    );
+    if (!picked) throw new B402Error(B402ErrorCode.InvalidConfig,
+      `no Kamino reserve found for mint ${req.mint.toBase58()}${req.market ? ` in market ${req.market.toBase58()}` : ''}`);
+
+    const reserveAddr = picked.best.address;
+    const market = picked.best.market;
+    const reserve = km.parseReserve(picked.best.data, market);
+    const outMint = reserve.collateralMint;
+    const perUser = km.deriveAllPerUser(this._wallet!.spendingPub, reserve, market);
+    const adapterAuthority = km.adapterAuthorityPda();
+
+    const { adapterInTa, adapterOutTa } = await km.ensureAdapterScratchAtas({
+      conn: this.connection, admin, adapterAuthority,
+      inMint: req.mint, outMint,
+    });
+    await km.ensurePerUserSetup({
+      conn: this.connection, admin, perUser, reserve, adapterAuthority,
+    });
+
+    const { derivePendingInputsPda } = await import('./commit-inputs.js');
+    const [pendingInputsPda] = derivePendingInputsPda(
+      new PublicKey(this.programIds.b402Pool),
+      perUser.ownerPda.toBuffer(),
+    );
+    const altPubkey = await km.ensureAlt({
+      conn: this.connection, admin, market, reserveAddr, reserve, perUser,
+      pendingInputsPda, adapterAuthority, adapterInTa, adapterOutTa, outMint,
+      poolHelpers: { poolConfigPda, adapterRegistryPda, treeStatePda, tokenConfigPda, vaultPda },
+    });
+
+    const actionPayload = km.buildDepositPayload(reserveAddr, req.amount);
+    const adapterIxData = km.buildAdapterIxData(req.amount, 0n, actionPayload);
+    const remainingAccounts = km.buildDepositRemainingAccounts({ market, reserveAddr, reserve, perUser });
+    const photonRpc = createRpc(this.connection.rpcEndpoint, this.connection.rpcEndpoint);
+
+    return this.privateLend({
+      inMint: req.mint, outMint, amount: req.amount,
+      adapterProgramId: km.KAMINO_ADAPTER,
+      adapterInTa, adapterOutTa,
+      alt: altPubkey, photonRpc,
+      expectedOut: req.amount,
+      adapterIxData, actionPayload, remainingAccounts,
+      phase9DualNote: true, pendingInputsMode: true,
+    });
+  }
+
+  /**
+   * Atomic private redeem from a Kamino V2 reserve. Burns a voucher
+   * commitment minted by `b402.lend()` and reshields the underlying.
+   * Auto-finds the matching voucher in the local note store; pass
+   * `leafIndex` to pick a specific one.
+   *
+   * Mainnet only.
+   */
+  async redeem(req: {
+    /** Underlying mint (the one you lent). Voucher mint is the reserve's
+     *  collateral mint, derived from the discovered reserve. */
+    mint: PublicKey;
+    /** Pin a specific Kamino LendingMarket — must match the one used at
+     *  lend time. */
+    market?: PublicKey;
+    /** Optional Merkle leaf index of the voucher to burn. Default:
+     *  most-recent voucher in the SDK note store. */
+    leafIndex?: number;
+  }): Promise<PrivateSwapResult> {
+    if (this.cluster !== 'mainnet') {
+      throw new B402Error(B402ErrorCode.InvalidConfig,
+        `b402.redeem is mainnet-only (current cluster: ${this.cluster}).`);
+    }
+    await this.ready();
+    await this.status({ refresh: true });
+    const admin = this._requireRelayer('b402.redeem (Kamino setup txs)');
+    const { pickBestKaminoReserveByMint } = await import('./kamino-discover.js');
+    const km = await import('./kamino-mainnet.js');
+    const { createRpc } = await import('@lightprotocol/stateless.js');
+    const { getAssociatedTokenAddressSync, createAssociatedTokenAccountIdempotentInstruction } =
+      await import('@solana/spl-token');
+    const { Transaction } = await import('@solana/web3.js');
+
+    const picked = await pickBestKaminoReserveByMint(
+      this.connection, req.mint,
+      req.market ? { market: req.market } : {},
+    );
+    if (!picked) throw new B402Error(B402ErrorCode.InvalidConfig,
+      `no Kamino reserve found for mint ${req.mint.toBase58()}`);
+
+    const reserveAddr = picked.best.address;
+    const market = picked.best.market;
+    const reserve = km.parseReserve(picked.best.data, market);
+    const outMint = reserve.collateralMint; // voucher mint (input for redeem)
+    const perUser = km.deriveAllPerUser(this._wallet!.spendingPub, reserve, market);
+    const adapterAuthority = km.adapterAuthorityPda();
+
+    // Reverse adapter scratch ATAs: voucher in, underlying out.
+    const { adapterInTa: wAdapterInTa, adapterOutTa: wAdapterOutTa } =
+      await km.ensureAdapterScratchAtas({
+        conn: this.connection, admin, adapterAuthority,
+        inMint: outMint, outMint: req.mint,
+      });
+    await km.ensurePerUserSetup({
+      conn: this.connection, admin, perUser, reserve, adapterAuthority,
+    });
+
+    // The pool's adapt_execute requires fee_ata_sentinel = relayer's ATA
+    // for the IN mint. For redeem, IN mint is the voucher (collateral).
+    // Pre-create idempotently — anyone can pay rent for a relayer-owned ATA.
+    const relayerPubkey = this._relayerHttp?.client.pubkey ?? admin.publicKey;
+    const relayerVoucherAta = getAssociatedTokenAddressSync(outMint, relayerPubkey, true);
+    const existing = await this.connection.getAccountInfo(relayerVoucherAta);
+    if (!existing) {
+      const tx = new Transaction().add(
+        createAssociatedTokenAccountIdempotentInstruction(
+          admin.publicKey, relayerVoucherAta, relayerPubkey, outMint,
+        ),
+      );
+      const bh = await this.connection.getLatestBlockhash('confirmed');
+      tx.recentBlockhash = bh.blockhash;
+      tx.feePayer = admin.publicKey;
+      tx.sign(admin);
+      const sig = await this.connection.sendRawTransaction(tx.serialize(), {
+        skipPreflight: false, preflightCommitment: 'confirmed',
+      });
+      // Poll for confirm without WS subs.
+      const start = Date.now();
+      let interval = 2000;
+      while (Date.now() - start < 90_000) {
+        const r = await this.connection.getSignatureStatuses([sig], { searchTransactionHistory: false });
+        const s = r.value[0];
+        if (s?.confirmationStatus === 'confirmed' || s?.confirmationStatus === 'finalized') break;
+        if (s?.err) throw new Error(`relayer voucher ATA tx failed: ${JSON.stringify(s.err)}`);
+        await new Promise((r) => setTimeout(r, interval));
+        interval = Math.min(interval * 1.2, 5000);
+      }
+    }
+
+    const { derivePendingInputsPda } = await import('./commit-inputs.js');
+    const [pendingInputsPda] = derivePendingInputsPda(
+      new PublicKey(this.programIds.b402Pool),
+      perUser.ownerPda.toBuffer(),
+    );
+    const altPubkey = await km.ensureAlt({
+      conn: this.connection, admin, market, reserveAddr, reserve, perUser,
+      pendingInputsPda, adapterAuthority,
+      adapterInTa: wAdapterInTa, adapterOutTa: wAdapterOutTa, outMint: req.mint,
+      poolHelpers: { poolConfigPda, adapterRegistryPda, treeStatePda, tokenConfigPda, vaultPda },
+    });
+
+    // Pick the voucher note to burn.
+    const { leToFrReduced } = await import('@b402ai/solana-shared');
+    const voucherMintFr = leToFrReduced(outMint.toBytes());
+    const vouchers = this._notes!.getSpendable(voucherMintFr);
+    if (vouchers.length === 0) {
+      throw new B402Error(B402ErrorCode.NoSpendableNotes,
+        `no voucher notes for ${outMint.toBase58().slice(0, 8)}… — call b402.lend first or wait for the lend tx to finalize`);
+    }
+    let redeemNote = vouchers[0];
+    if (req.leafIndex !== undefined) {
+      const target = req.leafIndex;
+      const found = vouchers.find((n) => Number(n.leafIndex) === target);
+      if (!found) throw new B402Error(B402ErrorCode.InvalidConfig,
+        `leafIndex ${target} not in voucher notes`);
+      redeemNote = found;
+    } else {
+      const sorted = [...vouchers].sort((a, b) =>
+        Number(BigInt(b.leafIndex) - BigInt(a.leafIndex)));
+      redeemNote = sorted[0];
+    }
+    const ktIn = redeemNote.value;
+
+    const actionPayload = km.buildWithdrawPayload(reserveAddr, ktIn);
+    const adapterIxData = km.buildAdapterIxData(ktIn, 0n, actionPayload);
+    const remainingAccounts = km.buildWithdrawRemainingAccounts({ market, reserveAddr, reserve, perUser });
+    const photonRpc = createRpc(this.connection.rpcEndpoint, this.connection.rpcEndpoint);
+
+    return this.privateRedeem({
+      inMint: outMint, outMint: req.mint, amount: ktIn, note: redeemNote,
+      adapterProgramId: km.KAMINO_ADAPTER,
+      adapterInTa: wAdapterInTa, adapterOutTa: wAdapterOutTa,
+      alt: altPubkey, photonRpc,
+      expectedOut: 0n,
+      adapterIxData, actionPayload, remainingAccounts,
+      phase9DualNote: true, pendingInputsMode: true,
+    });
+  }
+
+  /**
+   * Lend underlying tokens into a registered yield protocol via its
+   * adapter. Low-level: caller supplies adapter wiring. Use `b402.lend()`
+   * for Kamino with auto-discovery + auto-setup.
    */
   async privateLend(req: PrivateSwapRequest): Promise<PrivateSwapResult> {
     return this.privateSwap(req);

--- a/packages/sdk/src/b402.ts
+++ b/packages/sdk/src/b402.ts
@@ -986,12 +986,41 @@ export class B402Solana {
     // on the heavyweight tx, lifting the v0-tx 1232 B ceiling that
     // today blocks per-user adapters at scale.
     if (req.pendingInputsMode) {
-      const { buildCommitInputsIx } = await import('./commit-inputs.js');
+      const { buildCommitInputsIx, derivePendingInputsPda } = await import('./commit-inputs.js');
       const spendingPubLe = bigintToLe32(this._wallet!.spendingPub);
+      const inputs = proof.publicInputsLeBytes.map((b) => new Uint8Array(b));
+
+      // Idempotency: if a prior attempt already wrote the same inputs to
+      // the per-user pending_inputs PDA, skip submitting a fresh commit
+      // tx. Saves ~$0.0009 + the round-trip latency, and avoids a redundant
+      // tx racing the previous one through Helius (where ws confirms can
+      // lag the chain by 30+ s under load).
+      // PDA layout: 8 (anchor disc) + 1 (version) + 32 × N (inputs) + ...
+      const [pendingPda] = derivePendingInputsPda(
+        new PublicKey(this.programIds.b402Pool),
+        spendingPubLe,
+      );
+      const existing = await this.connection.getAccountInfo(pendingPda, 'confirmed');
+      const expectedBytes = new Uint8Array(inputs.length * 32);
+      for (let i = 0; i < inputs.length; i++) expectedBytes.set(inputs[i], i * 32);
+      const PENDING_INPUTS_HEADER = 8 + 1; // disc + version byte
+      const alreadyCommitted =
+        existing &&
+        existing.data.length >= PENDING_INPUTS_HEADER + expectedBytes.length &&
+        existing.data[8] === 1 && // version flag — pool sets to 1 on commit
+        Buffer.from(existing.data).subarray(
+          PENDING_INPUTS_HEADER,
+          PENDING_INPUTS_HEADER + expectedBytes.length,
+        ).equals(Buffer.from(expectedBytes));
+
+      if (alreadyCommitted) {
+        // Skip the commit tx entirely; adapt_execute_v2 below reads the
+        // PDA we already wrote.
+      } else {
       const commitIx = buildCommitInputsIx({
         poolProgramId: new PublicKey(this.programIds.b402Pool),
         spendingPubLe,
-        inputs: proof.publicInputsLeBytes.map((b) => new Uint8Array(b)),
+        inputs,
         relayer: relayerPubkey,
       });
       // Two paths:
@@ -1026,6 +1055,7 @@ export class B402Solana {
           'confirmed',
         );
       }
+      } // end else (alreadyCommitted check)
     }
 
     // 7. Adapter ix data: default mock-adapter shape (discriminator + amount +

--- a/packages/sdk/src/circuits.ts
+++ b/packages/sdk/src/circuits.ts
@@ -1,0 +1,161 @@
+/**
+ * Circuit artifact loader. Resolves wasm + zkey paths for the transact +
+ * adapt circuits with a content-addressed cache.
+ *
+ * Trust model:
+ *   - SHA256 hashes for all four artifacts are pinned in this file.
+ *   - The CDN serves untrusted bytes — every fetched file is verified
+ *     against its pinned hash before being placed in the cache. A
+ *     tampered CDN can DoS but cannot substitute a backdoored zkey.
+ *   - Cache key is the hash itself, not the URL — even if cache dir is
+ *     shared across versions, files cannot masquerade.
+ *
+ * Default cache: ~/.b402ai/circuits/<sha256>/<filename>
+ *
+ * Override the URL base with B402_CIRCUITS_URL_BASE for air-gapped /
+ * mirrored deployments. Override the cache root with B402_CIRCUITS_CACHE.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createHash } from 'node:crypto';
+
+export interface CircuitArtifact {
+  /** Public name of the file as it appears in the CDN. */
+  filename: string;
+  /** Pinned SHA256 of the file's bytes (hex, lowercase). */
+  sha256: string;
+  /** Expected size in bytes (early sanity check before hashing). */
+  size: number;
+}
+
+/**
+ * Pinned artifact descriptors. Update on every circuit-binary release.
+ * Hashes computed with `shasum -a 256 <file>`.
+ */
+export const TRANSACT_WASM: CircuitArtifact = {
+  filename: 'transact.wasm',
+  sha256: 'e7660490d3d99eeb47c2af0757927a834a9391194bb016c35debea075341ee4f',
+  size: 3_038_965,
+};
+export const TRANSACT_ZKEY: CircuitArtifact = {
+  filename: 'transact_final.zkey',
+  sha256: '0f2975e137582aa8a30855b3e0f4a1888538059ac8428232eee1d9d2eeae0506',
+  size: 12_359_270,
+};
+export const ADAPT_WASM: CircuitArtifact = {
+  filename: 'adapt.wasm',
+  sha256: 'ab7b3c3a309bd0c637b3a12006ee584b4afbae11231d2d8b513a270f3b1b3a64',
+  size: 3_129_641,
+};
+export const ADAPT_ZKEY: CircuitArtifact = {
+  filename: 'adapt_final.zkey',
+  sha256: '1d3cb5496cb1dd4dfbb923ce166f24cdfdffcb8a803fa1a36ea74071ede33f2a',
+  size: 18_565_200,
+};
+
+/**
+ * Default CDN — GitHub release for the pinned circuit set.
+ * Tag `circuits-v1` matches Pool Phase 9 + Adapter v2 deployed on mainnet.
+ */
+const DEFAULT_URL_BASE =
+  'https://github.com/mmchougule/b402-solana/releases/download/circuits-v1';
+
+function urlBase(): string {
+  return process.env.B402_CIRCUITS_URL_BASE ?? DEFAULT_URL_BASE;
+}
+
+function cacheRoot(): string {
+  return (
+    process.env.B402_CIRCUITS_CACHE
+    ?? path.join(os.homedir(), '.b402ai', 'circuits')
+  );
+}
+
+function cachePath(art: CircuitArtifact): string {
+  return path.join(cacheRoot(), art.sha256, art.filename);
+}
+
+function sha256File(p: string): string {
+  const h = createHash('sha256');
+  h.update(fs.readFileSync(p));
+  return h.digest('hex');
+}
+
+/**
+ * Resolve a circuit artifact, fetching + caching if needed.
+ *
+ * Returns the absolute path to a verified copy of the file. Throws on
+ * checksum mismatch — the caller should not retry blindly, since it
+ * indicates either CDN tampering or a stale pinned hash in this SDK
+ * version.
+ */
+export async function resolveCircuit(art: CircuitArtifact): Promise<string> {
+  const dest = cachePath(art);
+
+  if (fs.existsSync(dest)) {
+    const got = sha256File(dest);
+    if (got === art.sha256) return dest;
+    // Cache poisoned somehow — wipe and refetch.
+    fs.unlinkSync(dest);
+  }
+
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+
+  const url = `${urlBase()}/${art.filename}`;
+  // First call per artifact, every install. Log once so the user sees the
+  // ~10s cold-start instead of a silent stall.
+  console.error(`[b402] fetching circuit ${art.filename} (${(art.size / 1e6).toFixed(1)} MB)…`);
+
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok) {
+    throw new Error(
+      `circuit fetch failed: ${url} → HTTP ${res.status} ${res.statusText}. ` +
+      `Set B402_CIRCUITS_URL_BASE to a mirror or pre-populate ${dest}.`,
+    );
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+
+  if (buf.length !== art.size) {
+    throw new Error(
+      `circuit ${art.filename} size mismatch — expected ${art.size}, got ${buf.length}. ` +
+      `CDN may be serving a different version; refusing to cache.`,
+    );
+  }
+
+  const got = createHash('sha256').update(buf).digest('hex');
+  if (got !== art.sha256) {
+    throw new Error(
+      `circuit ${art.filename} checksum mismatch — expected ${art.sha256}, got ${got}. ` +
+      `CDN tampered or SDK pinned hash is stale; refusing to cache.`,
+    );
+  }
+
+  // Atomic write: tmp file + rename so a crashed download doesn't leave a
+  // half-file at the cache path.
+  const tmp = `${dest}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, buf);
+  fs.renameSync(tmp, dest);
+  return dest;
+}
+
+/**
+ * Resolve all four artifacts in parallel. Returns the {wasm,zkey} pair
+ * for each prover.
+ */
+export async function resolveAllCircuits(): Promise<{
+  transact: { wasmPath: string; zkeyPath: string };
+  adapt: { wasmPath: string; zkeyPath: string };
+}> {
+  const [tWasm, tZkey, aWasm, aZkey] = await Promise.all([
+    resolveCircuit(TRANSACT_WASM),
+    resolveCircuit(TRANSACT_ZKEY),
+    resolveCircuit(ADAPT_WASM),
+    resolveCircuit(ADAPT_ZKEY),
+  ]);
+  return {
+    transact: { wasmPath: tWasm, zkeyPath: tZkey },
+    adapt: { wasmPath: aWasm, zkeyPath: aZkey },
+  };
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -56,6 +56,29 @@ export {
   type KaminoPerUserAccounts,
 } from './kamino.js';
 
+// On-chain reserve discovery (no static reserve map).
+export {
+  KLEND_PROGRAM_ID,
+  RESERVE_DISCRIMINATOR,
+  LENDING_MARKET_DISCRIMINATOR,
+  RESERVE_ACCOUNT_SIZE,
+  LENDING_MARKET_ACCOUNT_SIZE,
+  RESERVE_LENDING_MARKET_OFFSET,
+  RESERVE_FARM_COLLATERAL_OFFSET,
+  RESERVE_LIQUIDITY_MINT_OFFSET,
+  RESERVE_TOKEN_INFO_NAME_OFFSET,
+  RESERVE_AVAILABLE_AMOUNT_OFFSET,
+  RESERVE_BORROWED_AMOUNT_SF_OFFSET,
+  discoverKaminoMarkets,
+  discoverKaminoReserves,
+  findKaminoReserveByMint,
+  findAllKaminoReservesByMint,
+  pickBestKaminoReserveByMint,
+  type DiscoveredReserve,
+  type DiscoveredMarket,
+  type DiscoverReservesOptions,
+} from './kamino-discover.js';
+
 /** Solana hard tx-size cap. */
 export const MAX_TX_SIZE = 1232;
 /** Soft ceiling for adapter action_payload. Pool recomputes keccak over it. */

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -56,6 +56,36 @@ export {
   type KaminoPerUserAccounts,
 } from './kamino.js';
 
+// Jupiter route helper — used internally by `b402.swap()` and exported
+// for callers who want to pre-fetch a quote then call `privateSwap()`.
+export {
+  fetchJupiterRoute,
+  type JupiterRouteRequest,
+  type JupiterRouteResponse,
+} from './jupiter-route.js';
+
+// Kamino mainnet helpers — used internally by `b402.lend()` / `b402.redeem()`.
+// Exported for advanced callers who want to compose Kamino flows manually
+// (e.g. their own multi-mint sweeper or APY-comparison UI).
+export {
+  POOL as KAMINO_POOL,
+  KAMINO_ADAPTER,
+  KLEND,
+  parseReserve,
+  deriveAllPerUser,
+  ensureAlt,
+  ensurePerUserSetup,
+  ensureAdapterScratchAtas,
+  adapterAuthorityPda,
+  buildDepositPayload,
+  buildWithdrawPayload,
+  buildAdapterIxData,
+  buildDepositRemainingAccounts,
+  buildWithdrawRemainingAccounts,
+  type ParsedReserve,
+  type PerUserAccounts,
+} from './kamino-mainnet.js';
+
 // On-chain reserve discovery (no static reserve map).
 export {
   KLEND_PROGRAM_ID,

--- a/packages/sdk/src/jupiter-route.ts
+++ b/packages/sdk/src/jupiter-route.ts
@@ -1,0 +1,89 @@
+/**
+ * Jupiter route fetcher used by `B402Solana.swap()`. Self-contained — no
+ * SDK-specific deps so it can be used standalone if a caller wants to
+ * pre-fetch a route and then construct a custom `privateSwap` ix.
+ *
+ * Routes go through Jupiter Lite API. Defaults to Phoenix-only direct
+ * routes because Phoenix has the smallest swap-ix account count for
+ * SOL/USDC, which fits the v0-tx 1232 B cap without per-call ALT
+ * extension. Override `dexes` for other venues.
+ */
+
+import { PublicKey } from '@solana/web3.js';
+
+export interface JupiterRouteRequest {
+  inMint: PublicKey;
+  outMint: PublicKey;
+  amount: bigint;
+  /** Slippage in basis points. 30 = 0.3%. */
+  slippageBps: number;
+  /** Pubkey Jupiter binds the swap to. For b402 this is the adapter
+   *  authority PDA so the swap proceeds end up in the adapter scratch
+   *  ATA owned by that PDA. */
+  userPublicKey: PublicKey;
+  /** Comma-separated DEX allowlist, e.g. "Phoenix" or "Phoenix,Raydium".
+   *  Default Phoenix. Pass `undefined` to allow all integrated DEXes
+   *  (route plan may exceed v0-tx cap). */
+  dexes?: string;
+  /** Whether to limit Jupiter to single-hop routes. Default true (multi-hop
+   *  blows past tx-size cap on most pairs). */
+  onlyDirectRoutes?: boolean;
+}
+
+export interface JupiterRouteResponse {
+  /** Raw Jupiter quote response (route plan, expected amounts, etc.). */
+  quote: {
+    outAmount: string;
+    otherAmountThreshold?: string;
+    routePlan?: unknown[];
+    [k: string]: unknown;
+  };
+  /** Raw Jupiter swap-instructions response. */
+  swap: {
+    swapInstruction: {
+      data: string; // base64
+      accounts: Array<{ pubkey: string; isSigner: boolean; isWritable: boolean }>;
+    };
+    addressLookupTableAddresses?: string[];
+    [k: string]: unknown;
+  };
+}
+
+/** Two-step Jupiter request: GET /quote → POST /swap-instructions. */
+export async function fetchJupiterRoute(
+  req: JupiterRouteRequest,
+): Promise<JupiterRouteResponse> {
+  const dexes = req.dexes ?? 'Phoenix';
+  const onlyDirect = req.onlyDirectRoutes ?? true;
+  const url =
+    `https://lite-api.jup.ag/swap/v1/quote?inputMint=${req.inMint.toBase58()}` +
+    `&outputMint=${req.outMint.toBase58()}` +
+    `&amount=${req.amount}` +
+    `&slippageBps=${req.slippageBps}` +
+    `&onlyDirectRoutes=${onlyDirect ? 'true' : 'false'}` +
+    `&dexes=${encodeURIComponent(dexes)}`;
+  const quoteRes = await fetch(url);
+  if (!quoteRes.ok) throw new Error(`Jupiter quote ${quoteRes.status}: ${await quoteRes.text().catch(() => '')}`);
+  const quote = (await quoteRes.json()) as JupiterRouteResponse['quote'];
+  if (!quote.outAmount) {
+    throw new Error(
+      `no Jupiter route ${req.inMint.toBase58().slice(0, 4)}→${req.outMint.toBase58().slice(0, 4)} ` +
+      `for ${req.amount} via dexes=[${dexes}] (onlyDirect=${onlyDirect}). Try widening dexes or disabling direct-only.`,
+    );
+  }
+  const swapBody = {
+    quoteResponse: quote,
+    userPublicKey: req.userPublicKey.toBase58(),
+    wrapAndUnwrapSol: false,
+    useSharedAccounts: false,
+  };
+  const swapRes = await fetch('https://lite-api.jup.ag/swap/v1/swap-instructions', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(swapBody),
+  });
+  if (!swapRes.ok) throw new Error(`Jupiter swap-instructions ${swapRes.status}`);
+  const swap = (await swapRes.json()) as JupiterRouteResponse['swap'];
+  if (!swap.swapInstruction) throw new Error(`Jupiter swap-instructions returned no swapInstruction: ${JSON.stringify(swap)}`);
+  return { quote, swap };
+}

--- a/packages/sdk/src/kamino-discover.ts
+++ b/packages/sdk/src/kamino-discover.ts
@@ -1,0 +1,234 @@
+/**
+ * On-chain discovery for Kamino markets + reserves.
+ *
+ * Markets and reserves are NOT derivable from a static seed/mint tuple —
+ * Kamino allocates each Reserve account at init time and stores the
+ * `lending_market` reference inside the Reserve struct (offset 32). The
+ * only way to enumerate them is `getProgramAccounts(KLEND)` filtered by
+ * the Reserve anchor discriminator.
+ *
+ * What this module gives you:
+ *   - `discoverKaminoMarkets(connection)` → every LendingMarket on chain
+ *   - `discoverKaminoReserves(connection, opts?)` → every Reserve, with
+ *     parsed market + liquidityMint + collateral mint
+ *   - `findKaminoReserveByMint(connection, mint, opts?)` → first reserve
+ *     whose liquidityMint matches; optionally constrained to a market
+ *
+ * Caching: getProgramAccounts is heavy on shared mainnet RPC. Caller is
+ * responsible for caching results (typical lifetime: ~minutes — markets
+ * and reserves change rarely).
+ *
+ * What this module does NOT do:
+ *   - APY / utilization / interest-model parsing (separate `kamino-apy`
+ *     module would handle that, reading interestRate fields from each
+ *     Reserve and applying Kamino's curve)
+ *   - Volume / TVL ranking (off-chain analytics, not in this lib)
+ *   - Picking the "best" market for a mint — caller's policy
+ */
+
+import { Connection, PublicKey } from '@solana/web3.js';
+
+/** KLend program id (mainnet). Kamino's lending core program. */
+export const KLEND_PROGRAM_ID = new PublicKey('KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD');
+
+/** Anchor disc for KLend `Reserve` accounts. */
+export const RESERVE_DISCRIMINATOR = Uint8Array.from([
+  43, 242, 204, 202, 26, 247, 59, 127,
+]);
+
+/** Anchor disc for KLend `LendingMarket` accounts. */
+export const LENDING_MARKET_DISCRIMINATOR = Uint8Array.from([
+  246, 114, 50, 98, 72, 157, 28, 120,
+]);
+
+/** Reserve account size (verified across mainnet reserves). */
+export const RESERVE_ACCOUNT_SIZE = 8624;
+
+/** LendingMarket account size (verified mainnet). */
+export const LENDING_MARKET_ACCOUNT_SIZE = 4664;
+
+/** Reserve struct field offsets (verified across multiple reserves). */
+export const RESERVE_LENDING_MARKET_OFFSET = 32;
+export const RESERVE_FARM_COLLATERAL_OFFSET = 64;
+export const RESERVE_LIQUIDITY_MINT_OFFSET = 128;
+/** TokenInfo.name (32-byte zero-padded ASCII symbol like "USDC\0…"). */
+export const RESERVE_TOKEN_INFO_NAME_OFFSET = 5032;
+
+/** Reserve.liquidity.available_amount (u64) — cash in the supply vault.
+ *  This is liquid supply only; borrowed funds are not here. */
+export const RESERVE_AVAILABLE_AMOUNT_OFFSET = 224;
+
+/** Reserve.liquidity.borrowed_amount_sf (u128, Kamino's "scaled fraction"
+ *  = raw_amount << 60). Add to available_amount for total supply. */
+export const RESERVE_BORROWED_AMOUNT_SF_OFFSET = 232;
+const KAMINO_FRACTION_SHIFT = 60n;
+
+/** Read a 32-byte symbol field, trim trailing zeros. */
+function readSymbol(data: Buffer): string {
+  const buf = data.subarray(RESERVE_TOKEN_INFO_NAME_OFFSET, RESERVE_TOKEN_INFO_NAME_OFFSET + 32);
+  const end = buf.indexOf(0);
+  return buf.subarray(0, end < 0 ? 32 : end).toString('utf8');
+}
+
+export interface DiscoveredReserve {
+  /** Reserve PDA (account address). */
+  address: PublicKey;
+  /** LendingMarket the reserve belongs to. */
+  market: PublicKey;
+  /** Liquidity mint (the token deposited). */
+  liquidityMint: PublicKey;
+  /** Symbol from on-chain TokenInfo.name (e.g. "USDC", "SOL"). */
+  symbol: string;
+  /** Reserve's farm-collateral pubkey, or PublicKey.default if no farm. */
+  farmCollateral: PublicKey;
+  /** Raw u64 of `liquidity.available_amount` — cash in supply vault. */
+  availableAmount: bigint;
+  /** Total supply in raw units (available + borrowed). The right depth
+   *  metric for ranking — established markets have most of their funds
+   *  borrowed, so available_amount alone underestimates them by 100x or
+   *  more. */
+  totalSupply: bigint;
+  /** Raw account bytes — caller can run a richer parser (oracles, etc.). */
+  data: Buffer;
+}
+
+export interface DiscoveredMarket {
+  /** LendingMarket account address. */
+  address: PublicKey;
+  /** Raw account bytes. */
+  data: Buffer;
+}
+
+/** All LendingMarket accounts owned by KLEND on the connected cluster.
+ *  ~10-30 results on mainnet, sub-second on Helius / Triton. */
+export async function discoverKaminoMarkets(
+  connection: Connection,
+): Promise<DiscoveredMarket[]> {
+  const accounts = await connection.getProgramAccounts(KLEND_PROGRAM_ID, {
+    commitment: 'confirmed',
+    filters: [
+      { dataSize: LENDING_MARKET_ACCOUNT_SIZE },
+      { memcmp: { offset: 0, bytes: bs58Encode(LENDING_MARKET_DISCRIMINATOR) } },
+    ],
+  });
+  return accounts.map((a) => ({
+    address: a.pubkey,
+    data: Buffer.from(a.account.data),
+  }));
+}
+
+export interface DiscoverReservesOptions {
+  /** Restrict to a specific market (e.g. "Main"). */
+  market?: PublicKey;
+}
+
+/** Every Reserve account owned by KLEND, parsed for the fields we need
+ *  to route a deposit/withdraw without re-reading the chain. */
+export async function discoverKaminoReserves(
+  connection: Connection,
+  options: DiscoverReservesOptions = {},
+): Promise<DiscoveredReserve[]> {
+  const filters: Parameters<Connection['getProgramAccounts']>[1] = {
+    commitment: 'confirmed',
+    filters: [
+      { dataSize: RESERVE_ACCOUNT_SIZE },
+      { memcmp: { offset: 0, bytes: bs58Encode(RESERVE_DISCRIMINATOR) } },
+    ],
+  };
+  if (options.market) {
+    filters.filters!.push({
+      memcmp: { offset: RESERVE_LENDING_MARKET_OFFSET, bytes: options.market.toBase58() },
+    });
+  }
+  const accounts = await connection.getProgramAccounts(KLEND_PROGRAM_ID, filters);
+
+  return accounts.map((a) => {
+    const data = Buffer.from(a.account.data);
+    const available = data.readBigUInt64LE(RESERVE_AVAILABLE_AMOUNT_OFFSET);
+    // borrowed_amount_sf is u128 little-endian at offset 232. Read as two
+    // u64s and combine. Kamino's scaled-fraction format means
+    // raw_borrowed = sf >> 60.
+    const borrowedLo = data.readBigUInt64LE(RESERVE_BORROWED_AMOUNT_SF_OFFSET);
+    const borrowedHi = data.readBigUInt64LE(RESERVE_BORROWED_AMOUNT_SF_OFFSET + 8);
+    const borrowedSf = borrowedLo | (borrowedHi << 64n);
+    const borrowedRaw = borrowedSf >> KAMINO_FRACTION_SHIFT;
+    return {
+      address: a.pubkey,
+      market: new PublicKey(data.subarray(RESERVE_LENDING_MARKET_OFFSET, RESERVE_LENDING_MARKET_OFFSET + 32)),
+      liquidityMint: new PublicKey(data.subarray(RESERVE_LIQUIDITY_MINT_OFFSET, RESERVE_LIQUIDITY_MINT_OFFSET + 32)),
+      symbol: readSymbol(data),
+      farmCollateral: new PublicKey(data.subarray(RESERVE_FARM_COLLATERAL_OFFSET, RESERVE_FARM_COLLATERAL_OFFSET + 32)),
+      availableAmount: available,
+      totalSupply: available + borrowedRaw,
+      data,
+    };
+  });
+}
+
+/** Pick the deepest reserve for a mint, returning the choice + the
+ *  alternates (sorted desc by availableAmount). Used by
+ *  private_lend / private_redeem to default to the largest-liquidity
+ *  match while exposing the runner-ups in the response so the caller
+ *  can switch markets next time.
+ *
+ *  Returns null if no reserve exists for the mint. */
+export async function pickBestKaminoReserveByMint(
+  connection: Connection,
+  mint: PublicKey,
+  options: DiscoverReservesOptions = {},
+): Promise<{ best: DiscoveredReserve; alternates: DiscoveredReserve[] } | null> {
+  const matches = await findAllKaminoReservesByMint(connection, mint, options);
+  if (matches.length === 0) return null;
+  // Sort by total supply (available + borrowed). Established markets have
+  // most of their funds borrowed out, so available_amount alone would
+  // unfairly favor low-utilization isolated markets.
+  matches.sort((a, b) => (a.totalSupply > b.totalSupply ? -1 : a.totalSupply < b.totalSupply ? 1 : 0));
+  return { best: matches[0], alternates: matches.slice(1) };
+}
+
+/** Find the first reserve (across all markets, or constrained to one)
+ *  whose liquidityMint == `mint`. Returns null if no match.
+ *
+ *  When the mint is listed in multiple markets and the caller hasn't
+ *  passed `options.market`, this returns whichever Kamino enumerated
+ *  first — order isn't stable across RPC calls. Prefer
+ *  `findAllKaminoReservesByMint` and let the caller / agent pick. */
+export async function findKaminoReserveByMint(
+  connection: Connection,
+  mint: PublicKey,
+  options: DiscoverReservesOptions = {},
+): Promise<DiscoveredReserve | null> {
+  const matches = await findAllKaminoReservesByMint(connection, mint, options);
+  return matches[0] ?? null;
+}
+
+/** Every reserve whose liquidityMint == `mint`. Empty if unsupported.
+ *
+ *  Use this when the mint can appear in multiple markets (USDC, SOL,
+ *  JLP, etc.) and the caller wants to surface the full picker / let the
+ *  user choose by APY, market name, or other policy. */
+export async function findAllKaminoReservesByMint(
+  connection: Connection,
+  mint: PublicKey,
+  options: DiscoverReservesOptions = {},
+): Promise<DiscoveredReserve[]> {
+  const all = await discoverKaminoReserves(connection, options);
+  return all.filter((r) => r.liquidityMint.equals(mint));
+}
+
+// — minimal base58 encoder for the memcmp filter without dragging bs58 in —
+// stateless.js / @solana/web3.js already pull bs58 transitively, but keeping
+// this import-free avoids a cross-package version pin.
+function bs58Encode(bytes: Uint8Array): string {
+  const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+  let zeros = 0;
+  while (zeros < bytes.length && bytes[zeros] === 0) zeros++;
+  let n = 0n;
+  for (const b of bytes) n = (n << 8n) + BigInt(b);
+  let out = '';
+  while (n > 0n) {
+    out = ALPHABET[Number(n % 58n)] + out;
+    n /= 58n;
+  }
+  return '1'.repeat(zeros) + out;
+}

--- a/packages/sdk/src/kamino-mainnet.ts
+++ b/packages/sdk/src/kamino-mainnet.ts
@@ -1,0 +1,553 @@
+/**
+ * Kamino-mainnet helpers shared by `private_lend` + `private_redeem` MCP tools.
+ *
+ * Encapsulates the per-user obligation derivation, reserve parsing,
+ * lazy ALT bootstrap, and the SPL ATA pre-create that the kamino-adapter
+ * requires. Mirrors `examples/mainnet-kamino-lend-demo.mjs` so tooling
+ * stays in lockstep with the e2e harness.
+ *
+ * Mainnet-only. The reserve + market + adapter pubkeys below are mainnet
+ * deployments.
+ */
+
+import {
+  AddressLookupTableAccount,
+  AddressLookupTableProgram,
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  type AccountMeta,
+} from '@solana/web3.js';
+import {
+  TOKEN_PROGRAM_ID,
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAssociatedTokenAddressSync,
+} from '@solana/spl-token';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+// ── mainnet program IDs ───────────────────────────────────────────────────────
+export const POOL = new PublicKey('42a3hsCXtQLWonyxWZosaaCJCweYYKMrvNd25p1Jrt2y');
+export const NULLIFIER = new PublicKey('2AnRZwWu6CTurZs1yQpqrcJWo4yRYL1xpeV78b2siweq');
+export const VERIFIER_T = new PublicKey('Afjbnv2Ekxa98jjRw33xPPhZabevek2uZxoE75kr6ZrK');
+export const VERIFIER_A = new PublicKey('3Y2tyhNSaUiW5AcZcmFGRyTMdnroxHxc5GqFQPcMTZae');
+export const KAMINO_ADAPTER = new PublicKey('2enwFgcGKJDqruHpCtvmhtxe3DYcV3k72VTvoGcdt2rX');
+export const KLEND = new PublicKey('KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD');
+export const FARMS_PROGRAM = new PublicKey('FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr');
+
+// USDC mainnet + Kamino main-market USDC reserve
+export const USDC = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+export const MARKET = new PublicKey('7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF');
+export const RESERVE = new PublicKey('D6q6wuQSrifJKZYpR1M8R4YawnLDtDsMmWM1NbBmgJ59');
+
+// Light Protocol V2 + sysvars
+export const LIGHT_SYSTEM_PROGRAM = new PublicKey('SySTEM1eSU2p4BGQfQpimFEWWSC1XDFeun3Nqzz3rT7');
+export const ACCOUNT_COMPRESSION_PROGRAM = new PublicKey('compr6CUsB5m2jS4Y3831ztGSTnDpnKJTKS95d64XVq');
+export const REGISTERED_PROGRAM_PDA = new PublicKey('35hkDgaAKwMCaxRz2ocSZ6NaUrtKkyNqU6c4RV3tYJRh');
+export const ACCOUNT_COMPRESSION_AUTHORITY = new PublicKey('HwXnGK3tPkkVY6P439H2p68AxpeuWXd5PcrAxFpbmfbA');
+export const ADDRESS_TREE = new PublicKey('amt2kaJA14v3urZbZvnc5v2np8jqvc4Z8zDep5wbtzx');
+export const OUTPUT_QUEUE = new PublicKey('oq5oh5ZR3yGomuQgFduNDzjtGvVWfDRGLuDVjv9a96P');
+export const SYSVAR_INSTRUCTIONS = new PublicKey('Sysvar1nstructions1111111111111111111111111');
+export const SYSVAR_RENT = new PublicKey('SysvarRent111111111111111111111111111111111');
+export const COMPUTE_BUDGET = new PublicKey('ComputeBudget111111111111111111111111111111');
+
+const ALT_PROGRAM = new PublicKey('AddressLookupTab1e1111111111111111111111111');
+
+// Adapter ix discriminator: sha256("global:execute")[..8]
+const EXECUTE_DISC = Uint8Array.from([130, 221, 242, 154, 13, 193, 189, 29]);
+
+// ── small helpers ─────────────────────────────────────────────────────────────
+/**
+ * Send + confirm a tx without WebSocket subscriptions. web3.js's
+ * `sendAndConfirmTransaction` uses confirmTransaction's WS-based path,
+ * which on Helius free tier returns 429 on the WS upgrade after a few
+ * subs and never delivers the confirmation event — leaving txs to
+ * "expire" even when they Finalized 30s prior. Poll instead.
+ */
+async function sendAndPollConfirm(
+  conn: Connection,
+  tx: Transaction,
+  signers: Keypair[],
+  timeoutMs: number = 90_000,
+): Promise<string> {
+  const bh = await conn.getLatestBlockhash('confirmed');
+  tx.recentBlockhash = bh.blockhash;
+  tx.feePayer = signers[0].publicKey;
+  tx.sign(...signers);
+  const sig = await conn.sendRawTransaction(tx.serialize(), {
+    skipPreflight: false,
+    preflightCommitment: 'confirmed',
+    maxRetries: 3,
+  });
+  const start = Date.now();
+  let interval = 2000;
+  while (Date.now() - start < timeoutMs) {
+    const res = await conn.getSignatureStatuses([sig], { searchTransactionHistory: false });
+    const s = res.value[0];
+    if (s) {
+      if (s.err) throw new Error(`tx ${sig} failed: ${JSON.stringify(s.err)}`);
+      if (s.confirmationStatus === 'confirmed' || s.confirmationStatus === 'finalized') return sig;
+    }
+    await new Promise((r) => setTimeout(r, interval));
+    interval = Math.min(interval * 1.2, 5000);
+  }
+  throw new Error(`tx ${sig} not confirmed within ${timeoutMs / 1000}s`);
+}
+
+function findUtf8(buf: Buffer, needle: string): number {
+  const b = Buffer.from(needle, 'utf8');
+  for (let i = 0; i < buf.length - b.length; i++) {
+    if (buf.subarray(i, i + b.length).equals(b)) return i;
+  }
+  return -1;
+}
+
+function reservePda(seed: string, market: PublicKey, mint: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from(seed), market.toBuffer(), mint.toBuffer()], KLEND,
+  )[0];
+}
+
+export function lendingMarketAuthorityPda(market: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync([Buffer.from('lma'), market.toBuffer()], KLEND)[0];
+}
+
+export function userMetadataPda(owner: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync([Buffer.from('user_meta'), owner.toBuffer()], KLEND)[0];
+}
+
+export function obligationPda(owner: PublicKey, market: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [
+      Buffer.from([0]), Buffer.from([0]),
+      owner.toBuffer(), market.toBuffer(),
+      PublicKey.default.toBuffer(), PublicKey.default.toBuffer(),
+    ], KLEND,
+  )[0];
+}
+
+export function obligationFarmPda(farm: PublicKey, obligation: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from('user'), farm.toBuffer(), obligation.toBuffer()], FARMS_PROGRAM,
+  )[0];
+}
+
+/** Per-(viewing_key, mint) PDA — matches the adapter's `derive_owner_pda`
+ *  in programs/b402-kamino-adapter/src/lib.rs. Each lending position
+ *  keyed by liquidity mint gets its own Kamino UserMetadata + Obligation,
+ *  so positions across mints are structurally independent. */
+export function deriveOwnerPda(adapter: PublicKey, hash: Buffer, mint: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from('b402/v1'), Buffer.from('adapter-owner'), hash, mint.toBuffer()], adapter,
+  )[0];
+}
+
+export function spendingPubToHashBytes(spendingPub: bigint): Buffer {
+  const buf = Buffer.alloc(32);
+  let v = spendingPub;
+  for (let i = 0; i < 32; i++) {
+    buf[i] = Number(v & 0xffn);
+    v >>= 8n;
+  }
+  return buf;
+}
+
+// ── reserve parsing ───────────────────────────────────────────────────────────
+export interface ParsedReserve {
+  liquidityMint: PublicKey;
+  liquiditySupply: PublicKey;
+  collateralMint: PublicKey;
+  collateralReserveDestSupply: PublicKey;
+  pyth: PublicKey | null;
+  switchboardPrice: PublicKey | null;
+  switchboardTwap: PublicKey | null;
+  scope: PublicKey | null;
+  reserveFarmCollateral: PublicKey;
+}
+
+/** Reserve struct field offsets shared with the SDK's kamino-discover. */
+const RESERVE_LIQUIDITY_MINT_OFFSET = 128;
+const RESERVE_FARM_COLLATERAL_OFFSET = 64;
+const RESERVE_TOKEN_INFO_NAME_OFFSET = 5032;
+
+/** Parse a Kamino reserve account into the per-reserve PDAs the adapter
+ *  needs. Uses fixed struct offsets only — no string-anchor search, so
+ *  it works for any mint (USDC, SOL, JitoSOL, BONK, …). The `market`
+ *  argument is required because the per-reserve sub-PDAs (liquidity
+ *  supply, collateral mint, etc.) are derived from `(market, mint)`. */
+export function parseReserve(data: Buffer, market: PublicKey): ParsedReserve {
+  const liquidityMint = new PublicKey(data.subarray(RESERVE_LIQUIDITY_MINT_OFFSET, RESERVE_LIQUIDITY_MINT_OFFSET + 32));
+  const reserveFarmCollateral = new PublicKey(data.subarray(RESERVE_FARM_COLLATERAL_OFFSET, RESERVE_FARM_COLLATERAL_OFFSET + 32));
+  const tokenInfoOff = RESERVE_TOKEN_INFO_NAME_OFFSET;
+  // Within TokenInfo: name(32) + heuristic(24) + maxAgePriceSeconds(8) + maxAgeTwapSeconds(8) + scopeConfig(...)
+  const scopeOff = tokenInfoOff + 32 + 24 + 24;
+  const swbOff = scopeOff + 52;
+  const pythOff = swbOff + 68;
+  const def = PublicKey.default;
+  const readPk = (off: number): PublicKey | null => {
+    const pk = new PublicKey(data.subarray(off, off + 32));
+    return pk.equals(def) ? null : pk;
+  };
+  return {
+    liquidityMint,
+    liquiditySupply: reservePda('reserve_liq_supply', market, liquidityMint),
+    collateralMint: reservePda('reserve_coll_mint', market, liquidityMint),
+    collateralReserveDestSupply: reservePda('reserve_coll_supply', market, liquidityMint),
+    pyth: readPk(pythOff),
+    switchboardPrice: readPk(swbOff),
+    switchboardTwap: readPk(swbOff + 32),
+    scope: readPk(scopeOff),
+    reserveFarmCollateral,
+  };
+}
+
+// ── per-user account bundle ──────────────────────────────────────────────────
+export interface PerUserAccounts {
+  ownerPda: PublicKey;
+  userMetadata: PublicKey;
+  obligation: PublicKey;
+  obligationFarm: PublicKey;
+  reserveFarmState: PublicKey;
+  ownerUsdcAta: PublicKey;
+  isFarmAttached: boolean;
+}
+
+export function deriveAllPerUser(
+  spendingPub: bigint,
+  reserve: ParsedReserve,
+  market: PublicKey,
+): PerUserAccounts {
+  const hash = spendingPubToHashBytes(spendingPub);
+  const ownerPda = deriveOwnerPda(KAMINO_ADAPTER, hash, reserve.liquidityMint);
+  const isFarmAttached = !reserve.reserveFarmCollateral.equals(PublicKey.default);
+  const obl = obligationPda(ownerPda, market);
+  return {
+    ownerPda,
+    userMetadata: userMetadataPda(ownerPda),
+    obligation: obl,
+    obligationFarm: isFarmAttached ? obligationFarmPda(reserve.reserveFarmCollateral, obl) : KLEND,
+    reserveFarmState: isFarmAttached ? reserve.reserveFarmCollateral : KLEND,
+    // Per-mint user ATA owned by ownerPda — was named `ownerUsdcAta` for the
+    // initial USDC-only flow but works for any mint via `reserve.liquidityMint`.
+    ownerUsdcAta: getAssociatedTokenAddressSync(reserve.liquidityMint, ownerPda, true),
+    isFarmAttached,
+  };
+}
+
+// ── ALT bootstrap ─────────────────────────────────────────────────────────────
+/** Persist one ALT per (market, mint) tuple. Different markets/mints have
+ *  disjoint reserve sub-PDAs; sharing one ALT across mints would force
+ *  re-extends on every switch, eating the 256-entry ALT cap fast. */
+function altPersistPathFor(market: PublicKey, mint: PublicKey): string {
+  return path.join(
+    os.homedir(),
+    '.b402-solana',
+    `kamino-mainnet-alt-${market.toBase58().slice(0, 8)}-${mint.toBase58().slice(0, 8)}.json`,
+  );
+}
+
+/** Load (or create + extend) the persisted ALT for Kamino lend/redeem. The
+ *  ALT contains all the static and per-user accounts that the lend/redeem
+ *  txs reference; without it the txs exceed the 1232-byte cap. */
+export async function ensureAlt(args: {
+  conn: Connection;
+  admin: Keypair;
+  market: PublicKey;
+  reserveAddr: PublicKey;
+  reserve: ParsedReserve;
+  perUser: PerUserAccounts;
+  pendingInputsPda: PublicKey;
+  adapterAuthority: PublicKey;
+  adapterInTa: PublicKey;
+  adapterOutTa: PublicKey;
+  outMint: PublicKey;
+  poolHelpers: {
+    poolConfigPda: (pool: PublicKey) => PublicKey;
+    adapterRegistryPda: (pool: PublicKey) => PublicKey;
+    treeStatePda: (pool: PublicKey) => PublicKey;
+    tokenConfigPda: (pool: PublicKey, mint: PublicKey) => PublicKey;
+    vaultPda: (pool: PublicKey, mint: PublicKey) => PublicKey;
+  };
+  altPersistPath?: string;
+}): Promise<PublicKey> {
+  const persistPath = args.altPersistPath ?? altPersistPathFor(args.market, args.reserve.liquidityMint);
+  fs.mkdirSync(path.dirname(persistPath), { recursive: true });
+
+  const NULLIFIER_CPI_AUTHORITY = PublicKey.findProgramAddressSync(
+    [Buffer.from('cpi_authority')], NULLIFIER,
+  )[0];
+
+  const inMint = args.reserve.liquidityMint;
+
+  const altShared = [
+    LIGHT_SYSTEM_PROGRAM, ACCOUNT_COMPRESSION_PROGRAM, REGISTERED_PROGRAM_PDA,
+    ACCOUNT_COMPRESSION_AUTHORITY, ADDRESS_TREE, OUTPUT_QUEUE,
+    NULLIFIER, NULLIFIER_CPI_AUTHORITY,
+    POOL,
+    args.poolHelpers.poolConfigPda(POOL),
+    args.poolHelpers.adapterRegistryPda(POOL),
+    args.poolHelpers.treeStatePda(POOL),
+    args.poolHelpers.tokenConfigPda(POOL, inMint),
+    args.poolHelpers.tokenConfigPda(POOL, args.outMint),
+    args.poolHelpers.vaultPda(POOL, inMint),
+    args.poolHelpers.vaultPda(POOL, args.outMint),
+    VERIFIER_A,
+    KAMINO_ADAPTER, args.adapterAuthority,
+    args.adapterInTa, args.adapterOutTa,
+    args.reserveAddr, args.market, lendingMarketAuthorityPda(args.market),
+    args.reserve.liquiditySupply, args.reserve.collateralMint,
+    args.reserve.collateralReserveDestSupply,
+    args.reserve.pyth ?? KLEND, args.reserve.switchboardPrice ?? KLEND,
+    args.reserve.switchboardTwap ?? KLEND, args.reserve.scope ?? KLEND,
+    args.reserve.liquidityMint, FARMS_PROGRAM,
+    SYSVAR_INSTRUCTIONS, COMPUTE_BUDGET, TOKEN_PROGRAM_ID,
+    SystemProgram.programId, SYSVAR_RENT, KLEND,
+  ];
+
+  const perUserCandidates = [
+    args.admin.publicKey,
+    args.perUser.ownerPda, args.perUser.userMetadata,
+    args.perUser.obligation, args.perUser.ownerUsdcAta,
+    ...(args.perUser.isFarmAttached ? [args.perUser.obligationFarm] : []),
+    ...(args.perUser.isFarmAttached && !args.perUser.reserveFarmState.equals(KLEND)
+      ? [args.perUser.reserveFarmState] : []),
+    args.pendingInputsPda,
+  ];
+
+  // Reuse persisted ALT if it still exists on chain.
+  let altPubkey: PublicKey | null = null;
+  let altIsFresh = false;
+  if (fs.existsSync(persistPath)) {
+    const persisted = new PublicKey(JSON.parse(fs.readFileSync(persistPath, 'utf8')).pubkey);
+    const info = await args.conn.getAccountInfo(persisted, 'confirmed');
+    if (info && info.owner.equals(ALT_PROGRAM)) {
+      altPubkey = persisted;
+    }
+  }
+
+  if (!altPubkey) {
+    const slot = Math.max(1, (await args.conn.getSlot('confirmed')) - 50);
+    const [createIx, fresh] = AddressLookupTableProgram.createLookupTable({
+      authority: args.admin.publicKey, payer: args.admin.publicKey, recentSlot: slot,
+    });
+    altPubkey = fresh;
+    altIsFresh = true;
+    await sendAndPollConfirm(args.conn, new Transaction().add(createIx), [args.admin]);
+    // Wait for ALT to be finalized + visible.
+    for (let i = 0; i < 60; i++) {
+      const info = await args.conn.getAccountInfo(altPubkey, 'finalized');
+      if (info && info.owner.equals(ALT_PROGRAM)) break;
+      if (i === 59) throw new Error('ALT not visible after 60s');
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+    fs.writeFileSync(persistPath, JSON.stringify({ pubkey: altPubkey.toBase58() }, null, 2));
+  }
+
+  // Extend with whatever's missing. Static block only needs to be extended on
+  // a fresh ALT; per-user PDAs always check.
+  const altInfo = await args.conn.getAccountInfo(altPubkey, 'confirmed');
+  const altDecoded = altInfo
+    ? AddressLookupTableAccount.deserialize(altInfo.data).addresses
+    : [];
+  const haveInAlt = (pk: PublicKey) => altDecoded.some((a) => a.equals(pk));
+
+  const targets: PublicKey[] = [];
+  if (altIsFresh) targets.push(...altShared);
+  for (const pk of perUserCandidates) {
+    if (!haveInAlt(pk) && !targets.some((t) => t.equals(pk))) targets.push(pk);
+  }
+
+  if (targets.length > 0) {
+    const CHUNK = 25;
+    for (let i = 0; i < targets.length; i += CHUNK) {
+      const ext = AddressLookupTableProgram.extendLookupTable({
+        payer: args.admin.publicKey, authority: args.admin.publicKey, lookupTable: altPubkey,
+        addresses: targets.slice(i, i + CHUNK),
+      });
+      await sendAndPollConfirm(args.conn, new Transaction().add(ext), [args.admin]);
+    }
+    // Brief wait so the next tx can resolve via the new entries.
+    await new Promise((r) => setTimeout(r, 4000));
+  }
+
+  return altPubkey;
+}
+
+// ── per-user setup (ATA + adapter authority pre-fund) ────────────────────────
+export async function ensurePerUserSetup(args: {
+  conn: Connection;
+  admin: Keypair;
+  perUser: PerUserAccounts;
+  reserve: ParsedReserve;
+  adapterAuthority: PublicKey;
+}): Promise<{ adapterFunded: boolean; ataCreated: boolean }> {
+  // Adapter authority needs ~0.5 SOL on first lend to pay for Kamino
+  // UserMetadata + Obligation account rent.
+  let adapterFunded = false;
+  const aaBal = await args.conn.getBalance(args.adapterAuthority);
+  if (aaBal < 0.05 * LAMPORTS_PER_SOL) {
+    await sendAndPollConfirm(args.conn,
+      new Transaction().add(
+        SystemProgram.transfer({
+          fromPubkey: args.admin.publicKey,
+          toPubkey: args.adapterAuthority,
+          lamports: 0.5 * LAMPORTS_PER_SOL,
+        }),
+      ),
+      [args.admin],
+    );
+    adapterFunded = true;
+  }
+
+  // Per-user USDC ATA owned by ownerPda. Required by Kamino's deposit_v2.
+  let ataCreated = false;
+  const ataInfo = await args.conn.getAccountInfo(args.perUser.ownerUsdcAta);
+  if (!ataInfo) {
+    const createAtaIx = createAssociatedTokenAccountIdempotentInstruction(
+      args.admin.publicKey, args.perUser.ownerUsdcAta,
+      args.perUser.ownerPda, args.reserve.liquidityMint,
+    );
+    await sendAndPollConfirm(args.conn, new Transaction().add(createAtaIx), [args.admin]);
+    ataCreated = true;
+  }
+
+  return { adapterFunded, ataCreated };
+}
+
+/** Adapter scratch ATAs (USDC + kUSDC, owned by adapterAuthority). */
+export async function ensureAdapterScratchAtas(args: {
+  conn: Connection;
+  admin: Keypair;
+  adapterAuthority: PublicKey;
+  inMint: PublicKey;
+  outMint: PublicKey;
+}): Promise<{ adapterInTa: PublicKey; adapterOutTa: PublicKey }> {
+  const inAta = getAssociatedTokenAddressSync(args.inMint, args.adapterAuthority, true);
+  const outAta = getAssociatedTokenAddressSync(args.outMint, args.adapterAuthority, true);
+  // Idempotent create — both ATAs in one tx if either is missing. Anyone
+  // can pay rent for an ATA owned by anyone else (PDA in this case).
+  const ixs = [];
+  const [inInfo, outInfo] = await Promise.all([
+    args.conn.getAccountInfo(inAta), args.conn.getAccountInfo(outAta),
+  ]);
+  if (!inInfo) ixs.push(createAssociatedTokenAccountIdempotentInstruction(
+    args.admin.publicKey, inAta, args.adapterAuthority, args.inMint,
+  ));
+  if (!outInfo) ixs.push(createAssociatedTokenAccountIdempotentInstruction(
+    args.admin.publicKey, outAta, args.adapterAuthority, args.outMint,
+  ));
+  if (ixs.length > 0) {
+    await sendAndPollConfirm(args.conn, new Transaction().add(...ixs), [args.admin]);
+  }
+  return { adapterInTa: inAta, adapterOutTa: outAta };
+}
+
+// ── ix data builders (deposit / withdraw) ─────────────────────────────────────
+function u32Le(n: number): Buffer { const b = Buffer.alloc(4); b.writeUInt32LE(n, 0); return b; }
+function u64Le(v: bigint): Buffer { const b = Buffer.alloc(8); b.writeBigUInt64LE(v, 0); return b; }
+
+export function buildDepositPayload(reserve: PublicKey, inAmount: bigint): Buffer {
+  // KaminoAction::Deposit { reserve, in_amount, min_kt_out=0 }
+  return Buffer.concat([
+    Buffer.from([0]),
+    reserve.toBuffer(),
+    u64Le(inAmount),
+    u64Le(0n),
+  ]);
+}
+
+export function buildWithdrawPayload(reserve: PublicKey, ktIn: bigint): Buffer {
+  // KaminoAction::Withdraw { reserve, kt_in, min_underlying_out=0 }
+  return Buffer.concat([
+    Buffer.from([1]),
+    reserve.toBuffer(),
+    u64Le(ktIn),
+    u64Le(0n),
+  ]);
+}
+
+export function buildAdapterIxData(inAmount: bigint, expectedOut: bigint, payload: Buffer): Uint8Array {
+  return new Uint8Array(Buffer.concat([
+    Buffer.from(EXECUTE_DISC),
+    u64Le(inAmount),
+    u64Le(expectedOut),
+    u32Le(payload.length),
+    payload,
+  ]));
+}
+
+// ── remaining_accounts builders ──────────────────────────────────────────────
+export function buildDepositRemainingAccounts(args: {
+  market: PublicKey;
+  reserveAddr: PublicKey;
+  reserve: ParsedReserve;
+  perUser: PerUserAccounts;
+}): AccountMeta[] {
+  const { reserve, perUser } = args;
+  const isFarm = perUser.isFarmAttached;
+  return [
+    { pubkey: args.reserveAddr, isSigner: false, isWritable: true },
+    { pubkey: args.market, isSigner: false, isWritable: false },
+    { pubkey: lendingMarketAuthorityPda(args.market), isSigner: false, isWritable: false },
+    { pubkey: reserve.liquiditySupply, isSigner: false, isWritable: true },
+    { pubkey: reserve.collateralMint, isSigner: false, isWritable: true },
+    { pubkey: reserve.collateralReserveDestSupply, isSigner: false, isWritable: true },
+    { pubkey: reserve.pyth ?? KLEND, isSigner: false, isWritable: false },
+    { pubkey: reserve.switchboardPrice ?? KLEND, isSigner: false, isWritable: false },
+    { pubkey: reserve.switchboardTwap ?? KLEND, isSigner: false, isWritable: false },
+    { pubkey: reserve.scope ?? KLEND, isSigner: false, isWritable: false },
+    { pubkey: reserve.liquidityMint, isSigner: false, isWritable: false },
+    { pubkey: FARMS_PROGRAM, isSigner: false, isWritable: false },
+    { pubkey: perUser.userMetadata, isSigner: false, isWritable: true },
+    { pubkey: perUser.obligation, isSigner: false, isWritable: true },
+    { pubkey: perUser.obligationFarm, isSigner: false, isWritable: isFarm },
+    { pubkey: perUser.reserveFarmState, isSigner: false, isWritable: isFarm },
+    { pubkey: SYSVAR_INSTRUCTIONS, isSigner: false, isWritable: false },
+    { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    { pubkey: SYSVAR_RENT, isSigner: false, isWritable: false },
+    { pubkey: perUser.ownerPda, isSigner: false, isWritable: true },           // 19
+    { pubkey: perUser.ownerUsdcAta, isSigner: false, isWritable: true },       // 20
+  ];
+}
+
+export function buildWithdrawRemainingAccounts(args: {
+  market: PublicKey;
+  reserveAddr: PublicKey;
+  reserve: ParsedReserve;
+  perUser: PerUserAccounts;
+}): AccountMeta[] {
+  const { reserve, perUser } = args;
+  const isFarm = perUser.isFarmAttached;
+  return [
+    { pubkey: args.reserveAddr, isSigner: false, isWritable: true },                         // 0
+    { pubkey: perUser.obligation, isSigner: false, isWritable: true },                       // 1
+    { pubkey: args.market, isSigner: false, isWritable: false },                             // 2
+    { pubkey: lendingMarketAuthorityPda(args.market), isSigner: false, isWritable: false },  // 3
+    { pubkey: reserve.collateralReserveDestSupply, isSigner: false, isWritable: true },      // 4
+    { pubkey: reserve.collateralMint, isSigner: false, isWritable: true },                   // 5
+    { pubkey: reserve.liquiditySupply, isSigner: false, isWritable: true },                  // 6
+    { pubkey: perUser.ownerUsdcAta, isSigner: false, isWritable: true },                     // 7
+    { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },                        // 8
+    { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },                        // 9
+    { pubkey: SYSVAR_INSTRUCTIONS, isSigner: false, isWritable: false },                     // 10
+    { pubkey: reserve.liquidityMint, isSigner: false, isWritable: false },                   // 11
+    { pubkey: perUser.ownerPda, isSigner: false, isWritable: true },                         // 12
+    { pubkey: reserve.pyth ?? KLEND, isSigner: false, isWritable: false },                   // 13
+    { pubkey: reserve.switchboardPrice ?? KLEND, isSigner: false, isWritable: false },       // 14
+    { pubkey: reserve.switchboardTwap ?? KLEND, isSigner: false, isWritable: false },        // 15
+    { pubkey: reserve.scope ?? KLEND, isSigner: false, isWritable: false },                  // 16
+    { pubkey: perUser.obligationFarm, isSigner: false, isWritable: isFarm },                 // 17
+    { pubkey: perUser.reserveFarmState, isSigner: false, isWritable: isFarm },               // 18
+    { pubkey: FARMS_PROGRAM, isSigner: false, isWritable: false },                           // 19
+  ];
+}
+
+export function adapterAuthorityPda(): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from('b402/v1'), Buffer.from('adapter')], KAMINO_ADAPTER,
+  )[0];
+}

--- a/packages/sdk/src/note-store.ts
+++ b/packages/sdk/src/note-store.ts
@@ -254,8 +254,16 @@ export class NoteStore {
       // page only — that's the cursor we'll persist after processing.
       if (page === 0) newestSig = sigs[0].signature;
 
-      const BATCH = 5;
+      // Tuned for free-tier RPC: BATCH=2 + 100ms inter-batch gap stays
+      // under ~15 req/s sustained, well below Helius free's 10 req/s
+      // soft limit when combined with Connection's built-in 429 backoff.
+      // First-run cost on a 30-sig page: 30 * (50ms tx + 100ms gap) ≈ 4.5s,
+      // acceptable for a one-time bootstrap. Subsequent calls hit the
+      // cursor early and do 0–2 tx fetches.
+      const BATCH = 2;
+      const INTER_BATCH_MS = 100;
       for (let i = 0; i < sigs.length; i += BATCH) {
+        if (i > 0) await new Promise((r) => setTimeout(r, INTER_BATCH_MS));
         const batch = sigs.slice(i, i + BATCH);
         const txs = await Promise.allSettled(
           batch.map((sig) =>

--- a/programs/b402-kamino-adapter/Cargo.toml
+++ b/programs/b402-kamino-adapter/Cargo.toml
@@ -14,6 +14,9 @@ no-idl = []
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []
+# Anchor 0.30 requires the idl-build feature on the program crate when
+# `anchor build` is run. Empty body — only enabled by the build pipeline.
+idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 # PRD-33 Phase 33.2: per-user Kamino obligation. When enabled, the action
 # payload's leading 32 B are interpreted as the user's viewing_pub_hash
 # (= bytes_le(outSpendingPub) from the Phase 9 adapt proof). The adapter

--- a/programs/b402-kamino-adapter/src/lib.rs
+++ b/programs/b402-kamino-adapter/src/lib.rs
@@ -429,14 +429,23 @@ pub mod b402_kamino_adapter {
                 require!(*act_in == in_amount, KaminoAdapterError::AmountMismatch);
                 #[cfg(feature = "per_user_obligation")]
                 {
+                    // Read liquidity_mint from the reserve account in
+                    // remaining_accounts[ra_deposit::RESERVE]. Required as a
+                    // PDA seed so each (viewing_key, mint) gets its own
+                    // independent Kamino obligation — preventing the
+                    // refresh_obligation walks-all-reserves problem and
+                    // making positions independently redeemable.
+                    let liquidity_mint =
+                        read_reserve_liquidity_mint(&ctx, ra_deposit::RESERVE)?;
                     let (expected_owner_pda, owner_bump) =
-                        derive_owner_pda(&crate::ID, &viewing_pub_hash);
+                        derive_owner_pda(&crate::ID, &viewing_pub_hash, &liquidity_mint);
                     handle_deposit_per_user(
                         &ctx,
                         *reserve,
                         *act_in,
                         *min_kt_out,
                         &viewing_pub_hash,
+                        liquidity_mint,
                         expected_owner_pda,
                         owner_bump,
                         bump,
@@ -453,14 +462,19 @@ pub mod b402_kamino_adapter {
                 require!(*kt_in == in_amount, KaminoAdapterError::AmountMismatch);
                 #[cfg(feature = "per_user_obligation")]
                 {
+                    // Same per-mint derivation as deposit. RA layout for
+                    // withdraw also has reserve at slot 0.
+                    let liquidity_mint =
+                        read_reserve_liquidity_mint(&ctx, ra_withdraw_per_user::WITHDRAW_RESERVE)?;
                     let (expected_owner_pda, owner_bump) =
-                        derive_owner_pda(&crate::ID, &viewing_pub_hash);
+                        derive_owner_pda(&crate::ID, &viewing_pub_hash, &liquidity_mint);
                     handle_withdraw_per_user(
                         &ctx,
                         *reserve,
                         *kt_in,
                         *min_underlying_out,
                         &viewing_pub_hash,
+                        liquidity_mint,
                         expected_owner_pda,
                         owner_bump,
                         bump,
@@ -1120,6 +1134,7 @@ fn handle_deposit_per_user<'info>(
     in_amount: u64,
     _min_kt_out: u64,
     viewing_pub_hash: &[u8; 32],
+    mint: Pubkey,
     expected_owner_pda: Pubkey,
     owner_bump: u8,
     auth_bump: u8,
@@ -1148,10 +1163,12 @@ fn handle_deposit_per_user<'info>(
     // post-CPI sweep). `owner_seeds` signs for `owner_pda` (Kamino-side
     // obligation owner). PRD-33 §3.3.
     let auth_seeds: &[&[u8]] = &[VERSION_PREFIX, SEED_ADAPTER, &[auth_bump]];
+    let mint_seed = mint.as_ref();
     let owner_seeds: &[&[u8]] = &[
         VERSION_PREFIX,
         SEED_ADAPTER_OWNER,
         viewing_pub_hash.as_ref(),
+        mint_seed,
         &[owner_bump],
     ];
     let signer_seeds: &[&[&[u8]]] = &[auth_seeds, owner_seeds];
@@ -1428,6 +1445,7 @@ fn handle_withdraw_per_user<'info>(
     kt_in: u64,
     _min_underlying_out: u64,
     viewing_pub_hash: &[u8; 32],
+    mint: Pubkey,
     expected_owner_pda: Pubkey,
     owner_bump: u8,
     auth_bump: u8,
@@ -1450,10 +1468,12 @@ fn handle_withdraw_per_user<'info>(
     let owner_key = owner_pda_info.key();
 
     let auth_seeds: &[&[u8]] = &[VERSION_PREFIX, SEED_ADAPTER, &[auth_bump]];
+    let mint_seed = mint.as_ref();
     let owner_seeds: &[&[u8]] = &[
         VERSION_PREFIX,
         SEED_ADAPTER_OWNER,
         viewing_pub_hash.as_ref(),
+        mint_seed,
         &[owner_bump],
     ];
     let signer_seeds: &[&[&[u8]]] = &[auth_seeds, owner_seeds];
@@ -1870,9 +1890,39 @@ pub enum KaminoAdapterError {
 /// own `program_id`) makes the same `viewing_pub_hash` resolve to a
 /// DIFFERENT `owner_pda` on Drift / Marginfi adapters — cross-protocol
 /// correlation by `owner_pda` alone is impossible.
-pub fn derive_owner_pda(adapter_program_id: &Pubkey, viewing_pub_hash: &[u8; 32]) -> (Pubkey, u8) {
+/// Read `liquidity.mint_pubkey` from a Kamino Reserve account at offset 128.
+/// Returns `KaminoCpiFailed` if the account is too short or the slot can't be
+/// parsed. The Reserve struct's mint offset is stable across reserves —
+/// verified empirically against USDC + SOL reserves on mainnet.
+fn read_reserve_liquidity_mint(
+    ctx: &Context<'_, '_, '_, '_, Execute<'_>>,
+    ra_index: usize,
+) -> Result<Pubkey> {
+    const LIQUIDITY_MINT_OFFSET: usize = 128;
+    let info = &ctx.remaining_accounts[ra_index];
+    let data = info.try_borrow_data().map_err(|_| KaminoAdapterError::KaminoCpiFailed)?;
+    require!(
+        data.len() >= LIQUIDITY_MINT_OFFSET + 32,
+        KaminoAdapterError::KaminoCpiFailed
+    );
+    let mut buf = [0u8; 32];
+    buf.copy_from_slice(&data[LIQUIDITY_MINT_OFFSET..LIQUIDITY_MINT_OFFSET + 32]);
+    Ok(Pubkey::new_from_array(buf))
+}
+
+/// Derive the per-(viewing_key, mint) `owner_pda`. Each lending position
+/// keyed by liquidity mint gets its own Kamino UserMetadata + Obligation,
+/// so positions across mints (USDC, SOL, JitoSOL, …) are structurally
+/// independent — no shared collateralization, no Klend's `RefreshObligation`
+/// having to walk every existing reserve when adding a new one. PRD-33 §3.3
+/// (extended).
+pub fn derive_owner_pda(
+    adapter_program_id: &Pubkey,
+    viewing_pub_hash: &[u8; 32],
+    mint: &Pubkey,
+) -> (Pubkey, u8) {
     Pubkey::find_program_address(
-        &[VERSION_PREFIX, SEED_ADAPTER_OWNER, viewing_pub_hash.as_ref()],
+        &[VERSION_PREFIX, SEED_ADAPTER_OWNER, viewing_pub_hash.as_ref(), mint.as_ref()],
         adapter_program_id,
     )
 }

--- a/programs/b402-kamino-adapter/src/lib.rs
+++ b/programs/b402-kamino-adapter/src/lib.rs
@@ -1890,26 +1890,6 @@ pub enum KaminoAdapterError {
 /// own `program_id`) makes the same `viewing_pub_hash` resolve to a
 /// DIFFERENT `owner_pda` on Drift / Marginfi adapters — cross-protocol
 /// correlation by `owner_pda` alone is impossible.
-/// Read `liquidity.mint_pubkey` from a Kamino Reserve account at offset 128.
-/// Returns `KaminoCpiFailed` if the account is too short or the slot can't be
-/// parsed. The Reserve struct's mint offset is stable across reserves —
-/// verified empirically against USDC + SOL reserves on mainnet.
-fn read_reserve_liquidity_mint(
-    ctx: &Context<'_, '_, '_, '_, Execute<'_>>,
-    ra_index: usize,
-) -> Result<Pubkey> {
-    const LIQUIDITY_MINT_OFFSET: usize = 128;
-    let info = &ctx.remaining_accounts[ra_index];
-    let data = info.try_borrow_data().map_err(|_| KaminoAdapterError::KaminoCpiFailed)?;
-    require!(
-        data.len() >= LIQUIDITY_MINT_OFFSET + 32,
-        KaminoAdapterError::KaminoCpiFailed
-    );
-    let mut buf = [0u8; 32];
-    buf.copy_from_slice(&data[LIQUIDITY_MINT_OFFSET..LIQUIDITY_MINT_OFFSET + 32]);
-    Ok(Pubkey::new_from_array(buf))
-}
-
 /// Derive the per-(viewing_key, mint) `owner_pda`. Each lending position
 /// keyed by liquidity mint gets its own Kamino UserMetadata + Obligation,
 /// so positions across mints (USDC, SOL, JitoSOL, …) are structurally

--- a/programs/b402-kamino-adapter/tests/per_user_payload.rs
+++ b/programs/b402-kamino-adapter/tests/per_user_payload.rs
@@ -71,24 +71,33 @@ fn decode_per_user_payload_rejects_missing_inner_action() {
     );
 }
 
+/// Mainnet USDC for the per-mint PDA tests below — any 32-byte pubkey
+/// works, USDC is just a stable choice.
+const USDC_MINT_BYTES: [u8; 32] = [
+    198, 250, 122, 243, 190, 219, 173, 58, 61, 101, 243, 106, 171, 201, 116, 49,
+    177, 187, 228, 194, 210, 246, 224, 228, 124, 166, 2, 3, 69, 47, 93, 97,
+];
+
 #[test]
 fn derive_owner_pda_is_deterministic() {
     let h = fixed_hash(0x11);
-    let (a, b1) = derive_owner_pda(&ADAPTER_ID, &h);
-    let (a2, b2) = derive_owner_pda(&ADAPTER_ID, &h);
-    assert_eq!(a, a2, "same hash → same PDA");
-    assert_eq!(b1, b2, "same hash → same bump");
+    let mint = Pubkey::new_from_array(USDC_MINT_BYTES);
+    let (a, b1) = derive_owner_pda(&ADAPTER_ID, &h, &mint);
+    let (a2, b2) = derive_owner_pda(&ADAPTER_ID, &h, &mint);
+    assert_eq!(a, a2, "same hash + mint → same PDA");
+    assert_eq!(b1, b2, "same hash + mint → same bump");
 }
 
 #[test]
 fn three_distinct_users_get_three_distinct_owner_pdas() {
+    let mint = Pubkey::new_from_array(USDC_MINT_BYTES);
     let alice_hash = fixed_hash(0xA1);
     let bob_hash = fixed_hash(0xB2);
     let carol_hash = fixed_hash(0xC3);
 
-    let (alice_pda, _) = derive_owner_pda(&ADAPTER_ID, &alice_hash);
-    let (bob_pda, _) = derive_owner_pda(&ADAPTER_ID, &bob_hash);
-    let (carol_pda, _) = derive_owner_pda(&ADAPTER_ID, &carol_hash);
+    let (alice_pda, _) = derive_owner_pda(&ADAPTER_ID, &alice_hash, &mint);
+    let (bob_pda, _) = derive_owner_pda(&ADAPTER_ID, &bob_hash, &mint);
+    let (carol_pda, _) = derive_owner_pda(&ADAPTER_ID, &carol_hash, &mint);
 
     assert_ne!(alice_pda, bob_pda, "alice ≠ bob owner_pda");
     assert_ne!(bob_pda, carol_pda, "bob ≠ carol owner_pda");
@@ -96,27 +105,45 @@ fn three_distinct_users_get_three_distinct_owner_pdas() {
 }
 
 #[test]
+fn same_user_different_mints_get_different_pdas() {
+    // Per-(viewing_key, mint) derivation: a single user lending USDC and
+    // SOL must end up with TWO independent Kamino obligations. Without
+    // this, refresh_obligation has to walk both reserves on every op and
+    // positions can't be redeemed independently.
+    let h = fixed_hash(0x44);
+    let usdc_mint = Pubkey::new_from_array(USDC_MINT_BYTES);
+    let sol_mint = Pubkey::new_from_array([
+        6, 155, 136, 87, 254, 171, 129, 132, 251, 104, 127, 99, 70, 24, 192,
+        53, 218, 196, 57, 220, 26, 235, 59, 85, 152, 160, 240, 0, 0, 0, 0, 1,
+    ]);
+    let (usdc_pda, _) = derive_owner_pda(&ADAPTER_ID, &h, &usdc_mint);
+    let (sol_pda, _) = derive_owner_pda(&ADAPTER_ID, &h, &sol_mint);
+    assert_ne!(usdc_pda, sol_pda, "same user, different mint → distinct PDA");
+}
+
+#[test]
 fn owner_pda_changes_with_one_bit_flip() {
+    let mint = Pubkey::new_from_array(USDC_MINT_BYTES);
     let mut h = fixed_hash(0x22);
-    let (orig_pda, _) = derive_owner_pda(&ADAPTER_ID, &h);
+    let (orig_pda, _) = derive_owner_pda(&ADAPTER_ID, &h, &mint);
     // Flip a single bit in the viewing_pub_hash.
     h[0] ^= 0x01;
-    let (perturbed_pda, _) = derive_owner_pda(&ADAPTER_ID, &h);
+    let (perturbed_pda, _) = derive_owner_pda(&ADAPTER_ID, &h, &mint);
     assert_ne!(orig_pda, perturbed_pda);
 }
 
 #[test]
-fn owner_pda_seeds_match_prd_33_section_3_2() {
-    // PRD-33 §3.2 pins the seed list. If anyone reorders these seeds the
-    // SDK-derived owner_pda diverges from the on-chain derivation and every
-    // per-user deposit dies with `KaminoCpiFailed` (signer seeds wrong).
-    // Pinning the exact byte representation here makes that drift loud.
+fn owner_pda_seeds_match_extended_layout() {
+    // Pinned seed list: ["b402/v1", "adapter-owner", viewing_pub_hash, mint].
+    // SDK derivation must match byte-for-byte or every per-user deposit
+    // dies with KaminoCpiFailed (signer seeds wrong).
     let h = fixed_hash(0x33);
+    let mint = Pubkey::new_from_array(USDC_MINT_BYTES);
     let (expected_pda, expected_bump) = Pubkey::find_program_address(
-        &[b"b402/v1", b"adapter-owner", h.as_ref()],
+        &[b"b402/v1", b"adapter-owner", h.as_ref(), mint.as_ref()],
         &ADAPTER_ID,
     );
-    let (actual_pda, actual_bump) = derive_owner_pda(&ADAPTER_ID, &h);
+    let (actual_pda, actual_bump) = derive_owner_pda(&ADAPTER_ID, &h, &mint);
     assert_eq!(actual_pda, expected_pda);
     assert_eq!(actual_bump, expected_bump);
 }


### PR DESCRIPTION
## Summary

- App integrators now add private DeFi in a few lines via `b402.shield()` / `b402.swap()` / `b402.lend()` / `b402.redeem()` — no circuit, relayer, indexer, or persistence config required.
- Circuit wasm/zkey resolved on first `ready()` from a SHA256-pinned GitHub release (`circuits-v1`) and content-addressed cache at `~/.b402ai/circuits/<sha>/`.
- Cross-session double-spend guard: indexer `/v1/spent` is consulted before picking a candidate note, fixing the "address already exists" failure when the local note store is stale.
- Scanner concurrency tuned for free-tier RPC; default note-store cursor persistence so subsequent refreshes are O(1).
- Post-shield indexer wait so a follow-up swap/lend on the same note doesn't race the merkle proof path.
- Kamino auto-discovery in `b402.lend()` — picks deepest reserve across all 182 mainnet markets; `market` opt-in for pinning.
- AGENTS.md + `.claude/skills/b402-private-defi/SKILL.md` so coding agents (Claude Code, Cursor, Codex) can integrate without reading the full source tree.
- `docs/getting-started.md` as canonical onboarding doc.

## Mainnet verification (zero-config end-to-end)

| Op | Sig |
|---|---|
| shield  | `BHQFQvvkEcwKWoCtwKSF9ayfjScGiCatrStS39RNn6SALV5sJqHwV4Y73YygCeypohGPsu4NUwMCQRsGnzsd2pe` |
| lend    | `ew4KHCKgD6B7M3WqhhRqtsDrrGo3q5q6yvMbSZxWhbFbPszsskztnPMWonwThrWz6o2AfenQQr4QWXeVwx6XGmM` |
| redeem  | `26B1zL8toATsrX7JcnBAkxq91J9RmwiEWa2asbsMWrkj6M2A8AwkrKZNa8KDcp2RrnNwix84TBwRnFJoG1PoXqa3` |

50,000 raw USDC → Kamino voucher → 49,999 raw USDC back (1 unit Kamino rounding dust).

## Versions published

- `@b402ai/solana@0.0.21`
- `@b402ai/solana-mcp@0.0.28`
- Circuit artifacts: GitHub release tag `circuits-v1`

## Test plan

- [x] Cold-fetch path: wipe `~/.b402ai/circuits`, run `examples/quickstart-private-lend.ts` → fetches all 4 artifacts, verifies SHA256, completes shield→lend→redeem.
- [x] Warm-cache path: same example with cache populated → no fetch, immediate run.
- [x] Indexer-aware spent filter: prior-session-spent note no longer triggers `Address already exists` from Light Protocol.
- [x] Scanner: cold backfill against Helius free tier — no 429 storm.
- [x] `npm view @b402ai/solana version` → `0.0.21`
- [x] `npm view @b402ai/solana-mcp version` → `0.0.28`

🤖 Generated with [Claude Code](https://claude.com/claude-code)