### PR TITLE
docs(site): tighten Slack/Twitter link previews

### DIFF
--- a/docs-site/introduction.mdx
+++ b/docs-site/introduction.mdx
@@ -1,6 +1,6 @@
 ---
-title: Introduction
-description: "Composable confidential DeFi on Solana — shielded pool + per-protocol adapters for Jupiter, Kamino, percolator, and beyond."
+title: Composable Confidential DeFi on Solana
+description: "Shield USDC, then swap, lend, or open perps privately on Solana mainnet — without your wallet on the transaction. SDK + MCP server, both live."
 ---
 
 `b402-solana` is a confidential DeFi layer for Solana. Shield USDC

--- a/docs-site/mint.json
+++ b/docs-site/mint.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mintlify.com/schema.json",
-  "name": "b402-solana",
+  "name": "b402 Docs",
   "logo": {
     "light": "/logo/b402-full-logo.png",
     "dark": "/logo/b402-full-logo.png"


### PR DESCRIPTION
Two-line meta fix:
- mint.json `name` → `b402 Docs` (matches Arcium / Aztec / Kamino preview pattern)
- introduction title → `Composable Confidential DeFi on Solana`; description tightened for sub-200-char preview slot
- Repo URLs in body / topbar / footer kept on mmchougule (this repo) — vistara-labs is the Mintlify deploy mirror only

Verified locally with mintlify broken-links: still clean.